### PR TITLE
fix getCredentials

### DIFF
--- a/cli/commands/init/index.ts
+++ b/cli/commands/init/index.ts
@@ -5,6 +5,7 @@ import prompts from 'prompts'
 import { assertExists, assertIsNonEmptyString, assertShellResult } from '../../utils'
 import { CreateKeyfile } from '../../utils/create.keyfile'
 import { CommandHandler } from '../..'
+import { ListKeyfiles } from '../../utils/list.keyfiles'
 
 export default function provideInit(
   shell: typeof shelljs,
@@ -12,6 +13,7 @@ export default function provideInit(
   filesystem: typeof fs,
   fortaKeystore: string,
   configFilename: string,
+  listKeyfiles: ListKeyfiles,
   createKeyfile: CreateKeyfile
 ): CommandHandler {
   assertExists(shell, 'shell')
@@ -19,6 +21,7 @@ export default function provideInit(
   assertExists(filesystem, 'filesystem')
   assertIsNonEmptyString(fortaKeystore, 'fortaKeystore')
   assertIsNonEmptyString(configFilename, 'configFilename')
+  assertExists(listKeyfiles, 'listKeyfiles')
   assertExists(createKeyfile, 'createKeyfile')
 
   return async function init(cliArgs: any) {
@@ -64,7 +67,7 @@ export default function provideInit(
     }
 
     // create keyfile if one doesnt already exist
-    const keyfiles = shell.ls(fortaKeystore).filter(filename => filename !== configFilename)
+    const keyfiles = listKeyfiles()
     if (!keyfiles.length) {
       console.log('creating new keyfile...')
       const { password } = await prompt({

--- a/cli/commands/publish/get.credentials.spec.ts
+++ b/cli/commands/publish/get.credentials.spec.ts
@@ -3,27 +3,26 @@ import provideGetCredentials, { GetCredentials } from "./get.credentials"
 
 describe("getCredentials", () => {
   let getCredentials: GetCredentials
-  const mockShell = {
-    ls: jest.fn()
-  } as any
   const mockPrompt = jest.fn() as any
   const mockFilesystem = {
     existsSync: jest.fn()
   } as any
+  const mockListKeyfiles = jest.fn()
   const mockGetKeyfile = jest.fn()
   const mockFortaKeystore = "some/key/store"
   const mockKeyfileName = "keyfileName"
   const mockKeyfilePath = path.join(mockFortaKeystore, mockKeyfileName)
 
   const resetMocks = () => {
-    mockShell.ls.mockReset()
     mockFilesystem.existsSync.mockReset()
     mockPrompt.mockReset()
+    mockListKeyfiles.mockReset()
     mockGetKeyfile.mockReset()
   }
 
   beforeAll(() => {
-    getCredentials = provideGetCredentials(mockShell, mockPrompt, mockFilesystem, mockGetKeyfile, mockFortaKeystore, mockKeyfileName)
+    getCredentials = provideGetCredentials(
+      mockPrompt, mockFilesystem, mockListKeyfiles, mockGetKeyfile, mockFortaKeystore, mockKeyfileName)
   })
 
   beforeEach(() => resetMocks())
@@ -72,7 +71,7 @@ describe("getCredentials", () => {
     expect(mockFilesystem.existsSync).toHaveBeenCalledTimes(2)
     expect(mockFilesystem.existsSync).toHaveBeenNthCalledWith(1, mockFortaKeystore)
     expect(mockFilesystem.existsSync).toHaveBeenNthCalledWith(2, mockKeyfilePath)
-    expect(mockShell.ls).toHaveBeenCalledTimes(0)
+    expect(mockListKeyfiles).toHaveBeenCalledTimes(0)
     expect(mockPrompt).toHaveBeenCalledTimes(1)
     expect(mockPrompt).toHaveBeenCalledWith({
       type: 'password',
@@ -88,14 +87,14 @@ describe("getCredentials", () => {
     mockFilesystem.existsSync.mockReturnValueOnce(true)
     const mockKeyfileName2 = 'mockKeyfileName2'
     const mockKeyfilePath2 = path.join(mockFortaKeystore, mockKeyfileName2)
-    mockShell.ls.mockReturnValueOnce([mockKeyfileName2])
+    mockListKeyfiles.mockReturnValueOnce([mockKeyfileName2])
     const mockPassword = 'password'
     mockPrompt.mockReturnValueOnce({ password: mockPassword })
     const mockPublicKey = "0x123"
     const mockPrivateKey = "0x456"
     mockGetKeyfile.mockReturnValueOnce({ publicKey: mockPublicKey, privateKey: mockPrivateKey })
 
-    getCredentials = provideGetCredentials(mockShell, mockPrompt, mockFilesystem, mockGetKeyfile, mockFortaKeystore)
+    getCredentials = provideGetCredentials(mockPrompt, mockFilesystem, mockListKeyfiles, mockGetKeyfile, mockFortaKeystore)
     const { publicKey, privateKey } = await getCredentials()
 
     expect(publicKey).toBe(mockPublicKey)
@@ -103,7 +102,8 @@ describe("getCredentials", () => {
     expect(mockFilesystem.existsSync).toHaveBeenCalledTimes(2)
     expect(mockFilesystem.existsSync).toHaveBeenNthCalledWith(1, mockFortaKeystore)
     expect(mockFilesystem.existsSync).toHaveBeenNthCalledWith(2, mockKeyfilePath2)
-    expect(mockShell.ls).toHaveBeenCalledTimes(1)
+    expect(mockListKeyfiles).toHaveBeenCalledTimes(1)
+    expect(mockListKeyfiles).toHaveBeenCalledWith()
     expect(mockPrompt).toHaveBeenCalledTimes(1)
     expect(mockPrompt).toHaveBeenCalledWith({
       type: 'password',

--- a/cli/commands/publish/get.credentials.ts
+++ b/cli/commands/publish/get.credentials.ts
@@ -4,21 +4,22 @@ import shelljs from "shelljs"
 import prompts from "prompts"
 import { assertExists, assertIsNonEmptyString } from "../../utils"
 import { GetKeyfile } from '../../utils/get.keyfile'
+import { ListKeyfiles } from '../../utils/list.keyfiles'
 
 // gets agent public and private key after prompting user for password
 export type GetCredentials = () => Promise<{ publicKey: string, privateKey: string }>
 
 export default function provideGetCredentials(
-  shell: typeof shelljs,
   prompt: typeof prompts,
   filesystem: typeof fs,
+  listKeyfiles: ListKeyfiles,
   getKeyfile: GetKeyfile,
   fortaKeystore: string,
   keyfileName?: string
 ): GetCredentials {
-  assertExists(shell, 'shell')
   assertExists(prompt, 'prompt')
   assertExists(filesystem, 'filesystem')
+  assertExists(listKeyfiles, 'listKeyfiles')
   assertExists(getKeyfile, 'getKeyfile')
   assertIsNonEmptyString(fortaKeystore, 'fortaKeystore')
 
@@ -29,8 +30,8 @@ export default function provideGetCredentials(
 
       // if a keyfile name is not specified in config
       if (!keyfileName) {
-        // assuming only one file in keystore
-        [ keyfileName ] = shell.ls(fortaKeystore)
+        // assuming only one keyfile in keystore
+        [ keyfileName ] = listKeyfiles()
       }
 
       const keyfilePath = path.join(fortaKeystore, keyfileName)

--- a/cli/di.container.ts
+++ b/cli/di.container.ts
@@ -35,6 +35,7 @@ import { provideRunHandlersOnBlock } from './utils/run.handlers.on.block'
 import { provideRunHandlersOnTransaction } from './utils/run.handlers.on.transaction'
 import provideAppendToFile from './utils/append.to.file'
 import provideGetFortaConfig, { GetFortaConfig } from './utils/get.forta.config'
+import provideListKeyfiles from './utils/list.keyfiles'
 
 export default function configureContainer(commandName: CommandName, cliArgs: any) {
   const container = createContainer({ injectionMode: InjectionMode.CLASSIC });
@@ -119,6 +120,7 @@ export default function configureContainer(commandName: CommandName, cliArgs: an
     createTransactionEvent: asValue(createTransactionEvent),
     getKeyfile: asFunction(provideGetKeyfile),
     createKeyfile: asFunction(provideCreateKeyfile),
+    listKeyfiles: asFunction(provideListKeyfiles),
     addToIpfs: asFunction(provideAddToIpfs),
     appendToFile: asFunction(provideAppendToFile),
 

--- a/cli/utils/list.keyfiles.ts
+++ b/cli/utils/list.keyfiles.ts
@@ -1,0 +1,19 @@
+import shelljs from 'shelljs'
+import { assertExists, assertIsNonEmptyString } from '.'
+
+// returns a list of keyfiles found in the keystore
+export type ListKeyfiles = () => string[]
+
+export default function provideListKeyfiles(
+  shell: typeof shelljs,
+  fortaKeystore: string,
+  configFilename: string,
+): ListKeyfiles {
+  assertExists(shell, 'shell')
+  assertIsNonEmptyString(fortaKeystore, 'fortaKeystore')
+  assertIsNonEmptyString(configFilename, 'configFilename')
+  
+  return function listKeyfiles() {
+    return shell.ls(fortaKeystore).filter(filename => filename !== configFilename)
+  }
+}


### PR DESCRIPTION
fixing `getCredentials` to filter out global config file when listing available keyfiles