### PR TITLE
keccak256 updated

### DIFF
--- a/python-sdk/src/forta_agent/utils.py
+++ b/python-sdk/src/forta_agent/utils.py
@@ -1,7 +1,7 @@
 import sys
 import os
 from jsonc_parser.parser import JsoncParser
-import sha3
+from Crypto.Hash import keccak
 
 
 def get_forta_config():
@@ -69,6 +69,6 @@ def hex_to_int(strVal):
 
 
 def keccak256(val):
-    hash = sha3.keccak_256()
+    hash = keccak.new(digest_bits=256)
     hash.update(bytes(val, encoding='utf-8'))
     return f'0x{hash.hexdigest()}'


### PR DESCRIPTION
This PR fixes the issue "Error: python: module 'sha3' has no attribute 'keccak_256'" using a built-in Crypto library.