### PR TITLE
refactor keyfile lookup

### DIFF
--- a/cli/commands/keyfile/index.spec.ts
+++ b/cli/commands/keyfile/index.spec.ts
@@ -1,0 +1,26 @@
+import provideKeyfile from "."
+import { CommandHandler } from "../.."
+
+describe("keyfile", () => {
+  let keyfile: CommandHandler
+  const mockGetKeyfile = jest.fn()
+  const mockGetJsonFile = jest.fn()
+
+  beforeAll(() => {
+    keyfile = provideKeyfile(mockGetKeyfile, mockGetJsonFile)
+  })
+
+  it("prints out keyfile path and address", async () => {
+    const mockPath = "/some/path/to/keyfile"
+    const mockAddress = "0x123"
+    mockGetKeyfile.mockReturnValueOnce({ path: mockPath })
+    mockGetJsonFile.mockReturnValueOnce({ address: mockAddress })
+
+    await keyfile({})
+
+    expect(mockGetKeyfile).toHaveBeenCalledTimes(1)
+    expect(mockGetKeyfile).toHaveBeenCalledWith()
+    expect(mockGetJsonFile).toHaveBeenCalledTimes(1)
+    expect(mockGetJsonFile).toHaveBeenCalledWith(mockPath)
+  })
+})

--- a/cli/commands/keyfile/index.ts
+++ b/cli/commands/keyfile/index.ts
@@ -1,31 +1,19 @@
-import fs from 'fs'
-import path from 'path'
 import { CommandHandler } from "../..";
-import { GetJsonFile } from '../../utils';
-import { ListKeyfiles } from "../../utils/list.keyfiles";
+import { assertExists, GetJsonFile } from '../../utils';
+import { GetKeyfile } from '../../utils/get.keyfile';
 
 export default function provideKeyfile(
-  listKeyfiles: ListKeyfiles,
+  getKeyfile: GetKeyfile,
   getJsonFile: GetJsonFile,
-  filesystem: typeof fs,
-  fortaKeystore: string,
-  keyfileName?: string
 ): CommandHandler {
+  assertExists(getKeyfile, 'getKeyfile')
+  assertExists(getJsonFile, 'getJsonFile')
 
   return async function keyfile() {
-    // if a keyfile name is not specified in config
-    if (!keyfileName) {
-      // assuming only one keyfile in keystore
-      [ keyfileName ] = listKeyfiles()
-    }
+    const { path } = getKeyfile()
+    const { address } = getJsonFile(path)
 
-    const keyfilePath = path.join(fortaKeystore, keyfileName)
-    if (!filesystem.existsSync(keyfilePath)) {
-      throw new Error(`keyfile not found at ${keyfilePath}`)
-    }
-    const { address } = getJsonFile(keyfilePath)
-
-    console.log(`path: ${keyfilePath}`)
+    console.log(`path: ${path}`)
     console.log(`address: 0x${address}`)
   }
 }

--- a/cli/di.container.ts
+++ b/cli/di.container.ts
@@ -27,7 +27,7 @@ import providePushToRegistry from './commands/publish/push.to.registry'
 import { createBlockEvent, createTransactionEvent, getJsonFile, keccak256 } from "./utils"
 import AgentRegistry from "./contracts/agent.registry"
 import { provideGetAgentHandlers } from "./utils/get.agent.handlers"
-import { provideGetKeyfile } from "./utils/get.keyfile"
+import { provideDecryptKeyfile } from "./utils/decrypt.keyfile"
 import { provideCreateKeyfile } from "./utils/create.keyfile"
 import provideGetCredentials from './utils/get.credentials'
 import { provideGetTraceData } from './utils/get.trace.data'
@@ -43,6 +43,7 @@ import provideListKeyfiles from './utils/list.keyfiles'
 import provideGetNetworkId from './utils/get.network.id'
 import provideGetBlockWithTransactions from './utils/get.block.with.transactions'
 import provideGetTransactionReceipt from './utils/get.transaction.receipt'
+import provideGetKeyfile from './utils/get.keyfile'
 
 export default function configureContainer(commandName: CommandName, cliArgs: any) {
   const container = createContainer({ injectionMode: InjectionMode.CLASSIC });
@@ -141,6 +142,7 @@ export default function configureContainer(commandName: CommandName, cliArgs: an
     createBlockEvent: asValue(createBlockEvent),
     createTransactionEvent: asValue(createTransactionEvent),
     getKeyfile: asFunction(provideGetKeyfile),
+    decryptKeyfile: asFunction(provideDecryptKeyfile),
     createKeyfile: asFunction(provideCreateKeyfile),
     listKeyfiles: asFunction(provideListKeyfiles),
     addToIpfs: asFunction(provideAddToIpfs),

--- a/cli/utils/decrypt.keyfile.ts
+++ b/cli/utils/decrypt.keyfile.ts
@@ -1,0 +1,16 @@
+import fs from 'fs'
+var keythereum = require("keythereum");
+
+// decrypts keyfile specified by keyfilePath using password
+export type DecryptKeyfile = (keyfilePath: string, password: string) => { publicKey: string, privateKey: string}
+
+export function provideDecryptKeyfile(): DecryptKeyfile {
+
+  return function decryptKeyfile(keyfilePath: string, password: string) {
+    const keyObject = JSON.parse(fs.readFileSync(keyfilePath).toString())
+    return {
+      publicKey: `0x${keyObject.address}`,
+      privateKey: `0x${keythereum.recover(password, keyObject).toString('hex')}`
+    }
+  }
+}

--- a/cli/utils/get.credentials.spec.ts
+++ b/cli/utils/get.credentials.spec.ts
@@ -4,118 +4,45 @@ import provideGetCredentials, { GetCredentials } from "./get.credentials"
 describe("getCredentials", () => {
   let getCredentials: GetCredentials
   const mockPrompt = jest.fn() as any
-  const mockFilesystem = {
-    existsSync: jest.fn()
-  } as any
-  const mockListKeyfiles = jest.fn()
   const mockGetKeyfile = jest.fn()
-  const mockFortaKeystore = "some/key/store"
-  const mockKeyfileName = "keyfileName--0xaddress"
-  const mockKeyfilePath = path.join(mockFortaKeystore, mockKeyfileName)
+  const mockDecryptKeyfile = jest.fn()
 
   const resetMocks = () => {
-    mockFilesystem.existsSync.mockReset()
     mockPrompt.mockReset()
-    mockListKeyfiles.mockReset()
     mockGetKeyfile.mockReset()
+    mockDecryptKeyfile.mockReset()
   }
 
   beforeAll(() => {
-    getCredentials = provideGetCredentials(
-      mockPrompt, mockFilesystem, mockListKeyfiles, mockGetKeyfile, mockFortaKeystore, mockKeyfileName)
+    getCredentials = provideGetCredentials(mockPrompt, mockGetKeyfile, mockDecryptKeyfile)
   })
 
   beforeEach(() => resetMocks())
 
-  it("throws error if keystore folder does not exist", async () => {
-    mockFilesystem.existsSync.mockReturnValueOnce(false)
-
-    try {
-      await getCredentials()
-    } catch (e) {
-      expect(e.message).toBe(`keystore folder ${mockFortaKeystore} not found`)
-    }
-
-    expect(mockFilesystem.existsSync).toHaveBeenCalledTimes(1)
-    expect(mockFilesystem.existsSync).toHaveBeenCalledWith(mockFortaKeystore)
-  })
-
-  it("throws error if keyfile path does not exist", async () => {
-    mockFilesystem.existsSync.mockReturnValueOnce(true)
-    mockFilesystem.existsSync.mockReturnValueOnce(false)
-    mockListKeyfiles.mockReturnValueOnce([mockKeyfileName])
-
-    try {
-      await getCredentials()
-    } catch (e) {
-      expect(e.message).toBe(`keyfile not found at ${mockKeyfilePath}`)
-    }
-
-    expect(mockFilesystem.existsSync).toHaveBeenCalledTimes(2)
-    expect(mockListKeyfiles).toHaveBeenCalledTimes(1)
-    expect(mockListKeyfiles).toHaveBeenCalledWith()
-    expect(mockFilesystem.existsSync).toHaveBeenNthCalledWith(1, mockFortaKeystore)
-    expect(mockFilesystem.existsSync).toHaveBeenNthCalledWith(2, mockKeyfilePath)
-  })
-
-  it("returns credentials from specified keyfile after prompting for password", async () => {
-    mockFilesystem.existsSync.mockReturnValueOnce(true)
-    mockFilesystem.existsSync.mockReturnValueOnce(true)
+  it("returns credentials from keyfile after prompting for password", async () => {
+    const mockFortaKeystore = "some/key/store"
+    const mockKeyfileName = "keyfileName--0xaddress"
+    const mockKeyfilePath = path.join(mockFortaKeystore, mockKeyfileName)
+    mockGetKeyfile.mockReturnValueOnce({ path: mockKeyfilePath, name: mockKeyfileName })
     const mockPassword = 'password'
     mockPrompt.mockReturnValueOnce({ password: mockPassword })
     const mockPublicKey = "0x123"
     const mockPrivateKey = "0x456"
-    mockGetKeyfile.mockReturnValueOnce({ publicKey: mockPublicKey, privateKey: mockPrivateKey })
-    mockListKeyfiles.mockReturnValueOnce([mockKeyfileName, "someOther--0xkeyfileaddress"])
+    mockDecryptKeyfile.mockReturnValueOnce({ publicKey: mockPublicKey, privateKey: mockPrivateKey })
 
     const { publicKey, privateKey } = await getCredentials()
 
     expect(publicKey).toBe(mockPublicKey)
     expect(privateKey).toBe(mockPrivateKey)
-    expect(mockFilesystem.existsSync).toHaveBeenCalledTimes(2)
-    expect(mockFilesystem.existsSync).toHaveBeenNthCalledWith(1, mockFortaKeystore)
-    expect(mockFilesystem.existsSync).toHaveBeenNthCalledWith(2, mockKeyfilePath)
-    expect(mockListKeyfiles).toHaveBeenCalledTimes(1)
-    expect(mockListKeyfiles).toHaveBeenCalledWith()
+    expect(mockGetKeyfile).toHaveBeenCalledTimes(1)
+    expect(mockGetKeyfile).toHaveBeenCalledWith()
     expect(mockPrompt).toHaveBeenCalledTimes(1)
     expect(mockPrompt).toHaveBeenCalledWith({
       type: 'password',
       name: 'password',
       message: `Enter password to decrypt keyfile ${mockKeyfileName}`
     })
-    expect(mockGetKeyfile).toHaveBeenCalledTimes(1)
-    expect(mockGetKeyfile).toHaveBeenCalledWith(mockKeyfilePath, mockPassword)
-  })
-
-  it("returns credentials from some unspecified keyfile after prompting for password", async () => {
-    mockFilesystem.existsSync.mockReturnValueOnce(true)
-    mockFilesystem.existsSync.mockReturnValueOnce(true)
-    const mockKeyfileName2 = 'mockKeyfileName2'
-    const mockKeyfilePath2 = path.join(mockFortaKeystore, mockKeyfileName2)
-    mockListKeyfiles.mockReturnValueOnce([mockKeyfileName2])
-    const mockPassword = 'password'
-    mockPrompt.mockReturnValueOnce({ password: mockPassword })
-    const mockPublicKey = "0x123"
-    const mockPrivateKey = "0x456"
-    mockGetKeyfile.mockReturnValueOnce({ publicKey: mockPublicKey, privateKey: mockPrivateKey })
-
-    getCredentials = provideGetCredentials(mockPrompt, mockFilesystem, mockListKeyfiles, mockGetKeyfile, mockFortaKeystore)
-    const { publicKey, privateKey } = await getCredentials()
-
-    expect(publicKey).toBe(mockPublicKey)
-    expect(privateKey).toBe(mockPrivateKey)
-    expect(mockFilesystem.existsSync).toHaveBeenCalledTimes(2)
-    expect(mockFilesystem.existsSync).toHaveBeenNthCalledWith(1, mockFortaKeystore)
-    expect(mockFilesystem.existsSync).toHaveBeenNthCalledWith(2, mockKeyfilePath2)
-    expect(mockListKeyfiles).toHaveBeenCalledTimes(1)
-    expect(mockListKeyfiles).toHaveBeenCalledWith()
-    expect(mockPrompt).toHaveBeenCalledTimes(1)
-    expect(mockPrompt).toHaveBeenCalledWith({
-      type: 'password',
-      name: 'password',
-      message: `Enter password to decrypt keyfile ${mockKeyfileName2}`
-    })
-    expect(mockGetKeyfile).toHaveBeenCalledTimes(1)
-    expect(mockGetKeyfile).toHaveBeenCalledWith(mockKeyfilePath2, mockPassword)
+    expect(mockDecryptKeyfile).toHaveBeenCalledTimes(1)
+    expect(mockDecryptKeyfile).toHaveBeenCalledWith(mockKeyfilePath, mockPassword)
   })
 })

--- a/cli/utils/get.credentials.ts
+++ b/cli/utils/get.credentials.ts
@@ -1,53 +1,29 @@
-import fs from 'fs'
-import path from 'path'
 import prompts from "prompts"
-import { assertExists, assertIsNonEmptyString } from "."
+import { assertExists } from "."
+import { DecryptKeyfile } from './decrypt.keyfile'
 import { GetKeyfile } from './get.keyfile'
-import { ListKeyfiles } from './list.keyfiles'
 
 // gets agent public and private key after prompting user for password
 export type GetCredentials = () => Promise<{ publicKey: string, privateKey: string }>
 
 export default function provideGetCredentials(
   prompt: typeof prompts,
-  filesystem: typeof fs,
-  listKeyfiles: ListKeyfiles,
   getKeyfile: GetKeyfile,
-  fortaKeystore: string,
-  keyfileName?: string
+  decryptKeyfile: DecryptKeyfile,
 ): GetCredentials {
   assertExists(prompt, 'prompt')
-  assertExists(filesystem, 'filesystem')
-  assertExists(listKeyfiles, 'listKeyfiles')
   assertExists(getKeyfile, 'getKeyfile')
-  assertIsNonEmptyString(fortaKeystore, 'fortaKeystore')
+  assertExists(decryptKeyfile, 'decryptKeyfile')
 
   return async function getCredentials() {
-      if (!filesystem.existsSync(fortaKeystore)) {
-        throw new Error(`keystore folder ${fortaKeystore} not found`)
-      }
+    const { path, name } = getKeyfile()
 
-      const keyfiles = listKeyfiles()
-      // if a keyfile name is not specified in config
-      if (!keyfileName) {
-        // assume only one keyfile in keystore
-        keyfileName = keyfiles[0]
-      } else {
-        // find the keyfile using the address in the specified filename (can't use filename directly since it may contain path separators)
-        const keyfileAddress = keyfileName.substr(keyfileName.lastIndexOf('--')+2)
-        keyfileName = keyfiles.find(keyfile => keyfile.endsWith(keyfileAddress))!
-      }
+    const { password } = await prompt({
+      type: 'password',
+      name: 'password',
+      message: `Enter password to decrypt keyfile ${name}`
+    })
 
-      const keyfilePath = path.join(fortaKeystore, keyfileName)
-      if (!filesystem.existsSync(keyfilePath)) {
-        throw new Error(`keyfile not found at ${keyfilePath}`)
-      }
-
-      const { password } = await prompt({
-        type: 'password',
-        name: 'password',
-        message: `Enter password to decrypt keyfile ${keyfileName}`
-      })
-      return getKeyfile(keyfilePath, password)
+    return decryptKeyfile(path, password)
   }
 }

--- a/cli/utils/get.keyfile.spec.ts
+++ b/cli/utils/get.keyfile.spec.ts
@@ -1,0 +1,91 @@
+import path from 'path'
+import provideGetKeyfile, { GetKeyfile } from "./get.keyfile"
+
+describe("getKeyfile", () => {
+  let getKeyfile: GetKeyfile
+  const mockListKeyfiles = jest.fn()
+  const mockFilesystem = {
+    existsSync: jest.fn()
+  } as any
+  const mockFortaKeystore = "/path/to/keystore"
+  const mockKeyfileName = "UTC--1234--5678abcd"
+  const mockKeyfilePath = path.join(mockFortaKeystore, mockKeyfileName)
+
+  const resetMocks = () => {
+    mockFilesystem.existsSync.mockReset()
+    mockListKeyfiles.mockReset()
+  }
+
+  beforeAll(() => {
+    getKeyfile = provideGetKeyfile(mockListKeyfiles, mockFilesystem, mockFortaKeystore, mockKeyfileName)
+  })
+
+  beforeEach(() => resetMocks())
+
+  it("throws error if keystore folder does not exist", async () => {
+    mockFilesystem.existsSync.mockReturnValueOnce(false)
+
+    try {
+      await getKeyfile()
+    } catch (e) {
+      expect(e.message).toBe(`keystore folder ${mockFortaKeystore} not found`)
+    }
+
+    expect(mockFilesystem.existsSync).toHaveBeenCalledTimes(1)
+    expect(mockFilesystem.existsSync).toHaveBeenCalledWith(mockFortaKeystore)
+  })
+
+
+  it("throws error if keyfile path does not exist", async () => {
+    mockFilesystem.existsSync.mockReturnValueOnce(true)
+    mockFilesystem.existsSync.mockReturnValueOnce(false)
+    mockListKeyfiles.mockReturnValueOnce([mockKeyfileName])
+
+    try {
+      await getKeyfile()
+    } catch (e) {
+      expect(e.message).toBe(`keyfile not found at ${mockKeyfilePath}`)
+    }
+
+    expect(mockFilesystem.existsSync).toHaveBeenCalledTimes(2)
+    expect(mockListKeyfiles).toHaveBeenCalledTimes(1)
+    expect(mockListKeyfiles).toHaveBeenCalledWith()
+    expect(mockFilesystem.existsSync).toHaveBeenNthCalledWith(1, mockFortaKeystore)
+    expect(mockFilesystem.existsSync).toHaveBeenNthCalledWith(2, mockKeyfilePath)
+  })
+
+  it("returns keyfile if specified in config", async () => {
+    mockFilesystem.existsSync.mockReturnValueOnce(true)
+    mockFilesystem.existsSync.mockReturnValueOnce(true)
+    const mockKeyfileName2 = "UTC--1234--9101xyzw"
+    mockListKeyfiles.mockReturnValueOnce([mockKeyfileName2, mockKeyfileName])
+
+    const { path: keyfilePath, name } = await getKeyfile()
+
+    expect(keyfilePath).toEqual(mockKeyfilePath)
+    expect(name).toEqual(mockKeyfileName)
+    expect(mockListKeyfiles).toHaveBeenCalledTimes(1)
+    expect(mockListKeyfiles).toHaveBeenCalledWith()
+    expect(mockFilesystem.existsSync).toHaveBeenCalledTimes(2)
+    expect(mockFilesystem.existsSync).toHaveBeenNthCalledWith(1, mockFortaKeystore)
+    expect(mockFilesystem.existsSync).toHaveBeenNthCalledWith(2, mockKeyfilePath)
+  })
+
+  it("returns first keyfile if none specified in config", async () => {
+    mockFilesystem.existsSync.mockReturnValueOnce(true)
+    mockFilesystem.existsSync.mockReturnValueOnce(true)
+    const mockKeyfileName2 = "UTC--1234--9101xyzw"
+    mockListKeyfiles.mockReturnValueOnce([mockKeyfileName, mockKeyfileName2])
+
+    getKeyfile = provideGetKeyfile(mockListKeyfiles, mockFilesystem, mockFortaKeystore)
+    const { path: keyfilePath, name } = await getKeyfile()
+
+    expect(keyfilePath).toEqual(mockKeyfilePath)
+    expect(name).toEqual(mockKeyfileName)
+    expect(mockListKeyfiles).toHaveBeenCalledTimes(1)
+    expect(mockListKeyfiles).toHaveBeenCalledWith()
+    expect(mockFilesystem.existsSync).toHaveBeenCalledTimes(2)
+    expect(mockFilesystem.existsSync).toHaveBeenNthCalledWith(1, mockFortaKeystore)
+    expect(mockFilesystem.existsSync).toHaveBeenNthCalledWith(2, mockKeyfilePath)
+  })
+})

--- a/cli/utils/get.keyfile.ts
+++ b/cli/utils/get.keyfile.ts
@@ -1,16 +1,45 @@
 import fs from 'fs'
-var keythereum = require("keythereum");
+import path from 'path'
+import { assertExists, assertIsNonEmptyString } from '.'
+import { ListKeyfiles } from './list.keyfiles'
 
-// decrypts keyfile specified by keyfilePath using password
-export type GetKeyfile = (keyfilePath: string, password: string) => Promise<{ publicKey: string, privateKey: string}>
+// returns the absolute path and name of the current working keyfile
+export type GetKeyfile = () => { path: string, name: string }
 
-export function provideGetKeyfile(): GetKeyfile {
+export default function provideGetKeyfile(
+  listKeyfiles: ListKeyfiles,
+  filesystem: typeof fs,
+  fortaKeystore: string,
+  keyfileName?: string
+): GetKeyfile {
+  assertExists(listKeyfiles, 'listKeyfiles')
+  assertExists(filesystem, 'filesystem')
+  assertIsNonEmptyString(fortaKeystore, 'fortaKeystore')
 
-  return async function getKeyfile(keyfilePath: string, password: string) {
-    const keyObject = JSON.parse(fs.readFileSync(keyfilePath).toString())
+  return function getKeyfile() {
+    if (!filesystem.existsSync(fortaKeystore)) {
+      throw new Error(`keystore folder ${fortaKeystore} not found`)
+    }
+
+    const keyfiles = listKeyfiles()
+    // if a keyfile name is not specified in config
+    if (!keyfileName) {
+      // assume only one keyfile in keystore
+      keyfileName = keyfiles[0]// TODO use some better way to select when there are multiple keyfiles
+    } else {
+      // find the keyfile using the address in the specified filename (can't use filename directly since it may contain path separators)
+      const keyfileAddress = keyfileName.substr(keyfileName.lastIndexOf('--')+2)
+      keyfileName = keyfiles.find(keyfile => keyfile.endsWith(keyfileAddress))!
+    }
+
+    const keyfilePath = path.join(fortaKeystore, keyfileName)
+    if (!filesystem.existsSync(keyfilePath)) {
+      throw new Error(`keyfile not found at ${keyfilePath}`)
+    }
+
     return {
-      publicKey: `0x${keyObject.address}`,
-      privateKey: `0x${keythereum.recover(password, keyObject).toString('hex')}`
+      path: keyfilePath,
+      name: keyfileName
     }
   }
 }


### PR DESCRIPTION
refactoring keyfile lookup logic into `getKeyfile` so it can be reused (currently duplicated between `getCredentials` and `keyfile` command)