### PR TITLE
add back process.exit for run command

### DIFF
--- a/cli/commands/run/index.spec.ts
+++ b/cli/commands/run/index.spec.ts
@@ -6,9 +6,11 @@ describe("run", () => {
   const mockContainer = {
     resolve: jest.fn()
   } as any
+  const mockExit = jest.spyOn(process, 'exit').mockImplementation();
 
   const resetMocks = () => {
     mockContainer.resolve.mockReset()
+    mockExit.mockReset()
   }
 
   beforeAll(() => {
@@ -28,6 +30,7 @@ describe("run", () => {
     expect(mockContainer.resolve).toHaveBeenCalledWith("runTransaction")
     expect(mockRunTransaction).toHaveBeenCalledTimes(1)
     expect(mockRunTransaction).toHaveBeenCalledWith(mockCliArgs.tx)
+    expect(mockExit).toHaveBeenCalledTimes(1)
   })
 
   it("invokes runBlock if block argument is provided", async () => {
@@ -41,6 +44,7 @@ describe("run", () => {
     expect(mockContainer.resolve).toHaveBeenCalledWith("runBlock")
     expect(mockRunBlock).toHaveBeenCalledTimes(1)
     expect(mockRunBlock).toHaveBeenCalledWith(mockCliArgs.block)
+    expect(mockExit).toHaveBeenCalledTimes(1)
   })
 
   it("invokes runBlockRange if range argument is provided", async () => {
@@ -54,6 +58,7 @@ describe("run", () => {
     expect(mockContainer.resolve).toHaveBeenCalledWith("runBlockRange")
     expect(mockRunBlockRange).toHaveBeenCalledTimes(1)
     expect(mockRunBlockRange).toHaveBeenCalledWith(mockCliArgs.range)
+    expect(mockExit).toHaveBeenCalledTimes(1)
   })
 
   it("invokes runFile if file argument is provided", async () => {
@@ -67,6 +72,7 @@ describe("run", () => {
     expect(mockContainer.resolve).toHaveBeenCalledWith("runFile")
     expect(mockRunFile).toHaveBeenCalledTimes(1)
     expect(mockRunFile).toHaveBeenCalledWith(mockCliArgs.file)
+    expect(mockExit).toHaveBeenCalledTimes(1)
   })
 
   it("invokes runProdServer if prod argument is provided", async () => {
@@ -80,6 +86,7 @@ describe("run", () => {
     expect(mockContainer.resolve).toHaveBeenCalledWith("runProdServer")
     expect(mockRunProdServer).toHaveBeenCalledTimes(1)
     expect(mockRunProdServer).toHaveBeenCalledWith()
+    expect(mockExit).toHaveBeenCalledTimes(0)
   })
 
   it("invokes runLive if no argument is provided", async () => {
@@ -93,5 +100,6 @@ describe("run", () => {
     expect(mockContainer.resolve).toHaveBeenCalledWith("runLive")
     expect(mockRunLive).toHaveBeenCalledTimes(1)
     expect(mockRunLive).toHaveBeenCalledWith()
+    expect(mockExit).toHaveBeenCalledTimes(0)
   })
 })

--- a/cli/commands/run/index.ts
+++ b/cli/commands/run/index.ts
@@ -35,6 +35,11 @@ export default function provideRun(
       const runLive = container.resolve<RunLive>("runLive")
       await runLive()
     }
+
+    // invoke process.exit() for short-lived functions, otherwise
+    // a child process (i.e. python agent process) can prevent commandline from returning
+    let isShortLived = cliArgs.tx || cliArgs.block || cliArgs.range || cliArgs.file
+    if (isShortLived) process.exit()
   }
 }
 

--- a/cli/utils/get.python.agent.handlers.ts
+++ b/cli/utils/get.python.agent.handlers.ts
@@ -4,7 +4,6 @@ import os from 'os'
 import { PythonShell } from 'python-shell'
 import ReadLines from 'n-readlines'
 import { BlockEvent, Finding, HandleBlock, HandleTransaction, TransactionEvent } from "../../sdk"
-import { assertIsNonEmptyString } from "."
 
 // imports python agent handlers from file wrapped in javascript
 export type GetPythonAgentHandlers = (pythonAgentPath: string) => Promise<{ handleTransaction?: HandleTransaction, handleBlock? : HandleBlock }>


### PR DESCRIPTION
adding back process.exit() in `run` command so that python agent process does not prevent completion