### PR TITLE
dont export getFortaConfig

### DIFF
--- a/python-sdk/src/forta_agent/__init__.py
+++ b/python-sdk/src/forta_agent/__init__.py
@@ -7,7 +7,7 @@ from .receipt import Receipt, Log
 from .trace import Trace, TraceAction, TraceResult
 from .event_type import EventType
 from .network import Network
-from .utils import get_forta_config, get_json_rpc_url, create_block_event, create_transaction_event, get_web3_provider
+from .utils import get_json_rpc_url, create_block_event, create_transaction_event, get_web3_provider
 from web3 import Web3
 
 web3Provider = Web3(Web3.HTTPProvider(get_json_rpc_url()))

--- a/sdk/index.ts
+++ b/sdk/index.ts
@@ -3,7 +3,7 @@ import { Finding, FindingSeverity, FindingType } from "./finding"
 import { BlockEvent } from "./block.event"
 import { Block } from "./block"
 import { TransactionEvent, TxEventBlock } from "./transaction.event"
-import { createBlockEvent, createTransactionEvent, getFortaConfig, getJsonRpcUrl, getEthersProvider } from "./utils"
+import { createBlockEvent, createTransactionEvent, getJsonRpcUrl, getEthersProvider } from "./utils"
 import { Log, Receipt } from "./receipt"
 import { Trace, TraceAction, TraceResult } from "./trace"
 import { Transaction } from "./transaction"
@@ -61,7 +61,6 @@ export {
   TraceResult,
   EventType,
   Network,
-  getFortaConfig,
   getJsonRpcUrl,
   createTransactionEvent,
   createBlockEvent,

--- a/sdk/utils.ts
+++ b/sdk/utils.ts
@@ -15,7 +15,7 @@ export const getEthersProvider = () => {
   return new ethers.providers.JsonRpcProvider(getJsonRpcUrl())
 }
 
-export const getFortaConfig: () => FortaConfig = () => {
+const getFortaConfig: () => FortaConfig = () => {
   let config = {}
   // try to read from global config
   const globalConfigPath = join(os.homedir(), '.forta', 'forta.config.json')


### PR DESCRIPTION
dont export `getFortaConfig` function since forta.config.json is only used for local development