### PR TITLE
apple m1 build fix

### DIFF
--- a/cli/commands/publish/upload.image.ts
+++ b/cli/commands/publish/upload.image.ts
@@ -28,7 +28,12 @@ export default function provideUploadImage(
     // build the agent image
     console.log('building agent image...')
     const containerTag = `${agentName}-intermediate`
-    const buildResult = shell.exec(`docker build --tag ${containerTag} .`)
+    let buildCommand = `docker build --tag ${containerTag} .`
+    if (isAppleM1()) {
+      // TODO should this just be the default build command?
+      buildCommand = `docker buildx build --platform linux/amd64 --tag ${containerTag} .`
+    }
+    const buildResult = shell.exec(buildCommand)
     assertShellResult(buildResult, 'error building agent image')
 
     // push agent image to repository

--- a/cli/utils/index.ts
+++ b/cli/utils/index.ts
@@ -1,3 +1,4 @@
+import os from 'os'
 import fs from 'fs'
 import path from 'path'
 import _ from 'lodash'
@@ -32,6 +33,10 @@ export const assertShellResult = (result: ShellString, errMsg: string) => {
   if (result.code !== 0) {
     throw new Error(`${errMsg}: ${result.stderr}`)
   }
+}
+
+export const isAppleM1 = () => {
+  return os.cpus().some(cpu => cpu.model.includes("Apple M1"))
 }
 
 export const keccak256 = (str: string) => {


### PR DESCRIPTION
fixing M1 Macbook docker build command. this was causing issues when building images on M1 Macbooks (i.e. would complain about python not being available when trying to build some dependencies like secp256k1). was also causing issues when running the image on the scan node (which uses linux/amd64 architecture) since docker on M1 was targeting arm64 architecture