### PR TITLE
add caching to cli

### DIFF
--- a/cli/commands/run/index.spec.ts
+++ b/cli/commands/run/index.spec.ts
@@ -6,20 +6,24 @@ describe("run", () => {
   const mockContainer = {
     resolve: jest.fn()
   } as any
+  const mockCache = {
+    save: jest.fn()
+  } as any
   const mockExit = jest.spyOn(process, 'exit').mockImplementation();
 
   const resetMocks = () => {
     mockContainer.resolve.mockReset()
+    mockCache.save.mockReset()
     mockExit.mockReset()
   }
 
   beforeAll(() => {
-    run = provideRun(mockContainer)
+    run = provideRun(mockContainer, mockCache)
   })
 
   beforeEach(() => resetMocks())
 
-  it("invokes runTransaction if tx argument is provided", async () => {
+  it("invokes runTransaction if --tx argument is provided", async () => {
     const mockCliArgs = {tx: '0x123'}
     const mockRunTransaction = jest.fn()
     mockContainer.resolve.mockReturnValueOnce(mockRunTransaction)
@@ -30,10 +34,12 @@ describe("run", () => {
     expect(mockContainer.resolve).toHaveBeenCalledWith("runTransaction")
     expect(mockRunTransaction).toHaveBeenCalledTimes(1)
     expect(mockRunTransaction).toHaveBeenCalledWith(mockCliArgs.tx)
+    expect(mockCache.save).toHaveBeenCalledTimes(1)
+    expect(mockCache.save).toHaveBeenCalledWith(true)
     expect(mockExit).toHaveBeenCalledTimes(1)
   })
 
-  it("invokes runBlock if block argument is provided", async () => {
+  it("invokes runBlock if --block argument is provided", async () => {
     const mockCliArgs = {block: '0xabc'}
     const mockRunBlock = jest.fn()
     mockContainer.resolve.mockReturnValueOnce(mockRunBlock)
@@ -44,10 +50,12 @@ describe("run", () => {
     expect(mockContainer.resolve).toHaveBeenCalledWith("runBlock")
     expect(mockRunBlock).toHaveBeenCalledTimes(1)
     expect(mockRunBlock).toHaveBeenCalledWith(mockCliArgs.block)
+    expect(mockCache.save).toHaveBeenCalledTimes(1)
+    expect(mockCache.save).toHaveBeenCalledWith(true)
     expect(mockExit).toHaveBeenCalledTimes(1)
   })
 
-  it("invokes runBlockRange if range argument is provided", async () => {
+  it("invokes runBlockRange if --range argument is provided", async () => {
     const mockCliArgs = {range: '1..2'}
     const mockRunBlockRange = jest.fn()
     mockContainer.resolve.mockReturnValueOnce(mockRunBlockRange)
@@ -58,10 +66,12 @@ describe("run", () => {
     expect(mockContainer.resolve).toHaveBeenCalledWith("runBlockRange")
     expect(mockRunBlockRange).toHaveBeenCalledTimes(1)
     expect(mockRunBlockRange).toHaveBeenCalledWith(mockCliArgs.range)
+    expect(mockCache.save).toHaveBeenCalledTimes(1)
+    expect(mockCache.save).toHaveBeenCalledWith(true)
     expect(mockExit).toHaveBeenCalledTimes(1)
   })
 
-  it("invokes runFile if file argument is provided", async () => {
+  it("invokes runFile if --file argument is provided", async () => {
     const mockCliArgs = {file: 'someFile.json'}
     const mockRunFile = jest.fn()
     mockContainer.resolve.mockReturnValueOnce(mockRunFile)
@@ -72,10 +82,12 @@ describe("run", () => {
     expect(mockContainer.resolve).toHaveBeenCalledWith("runFile")
     expect(mockRunFile).toHaveBeenCalledTimes(1)
     expect(mockRunFile).toHaveBeenCalledWith(mockCliArgs.file)
+    expect(mockCache.save).toHaveBeenCalledTimes(1)
+    expect(mockCache.save).toHaveBeenCalledWith(true)
     expect(mockExit).toHaveBeenCalledTimes(1)
   })
 
-  it("invokes runProdServer if prod argument is provided", async () => {
+  it("invokes runProdServer if --prod argument is provided", async () => {
     const mockCliArgs = {prod: true}
     const mockRunProdServer = jest.fn()
     mockContainer.resolve.mockReturnValueOnce(mockRunProdServer)
@@ -86,6 +98,8 @@ describe("run", () => {
     expect(mockContainer.resolve).toHaveBeenCalledWith("runProdServer")
     expect(mockRunProdServer).toHaveBeenCalledTimes(1)
     expect(mockRunProdServer).toHaveBeenCalledWith()
+    expect(mockCache.save).toHaveBeenCalledTimes(1)
+    expect(mockCache.save).toHaveBeenCalledWith(true)
     expect(mockExit).toHaveBeenCalledTimes(0)
   })
 
@@ -100,6 +114,8 @@ describe("run", () => {
     expect(mockContainer.resolve).toHaveBeenCalledWith("runLive")
     expect(mockRunLive).toHaveBeenCalledTimes(1)
     expect(mockRunLive).toHaveBeenCalledWith()
+    expect(mockCache.save).toHaveBeenCalledTimes(1)
+    expect(mockCache.save).toHaveBeenCalledWith(true)
     expect(mockExit).toHaveBeenCalledTimes(0)
   })
 })

--- a/cli/commands/run/index.ts
+++ b/cli/commands/run/index.ts
@@ -1,4 +1,5 @@
 import { AwilixContainer } from 'awilix';
+import { Cache } from 'flat-cache';
 import { CommandHandler } from '../..';
 import { assertExists } from '../../utils';
 import { RunBlock } from './run.block';
@@ -9,9 +10,11 @@ import { RunTransaction } from './run.transaction';
 import { RunProdServer } from './server';
 
 export default function provideRun(
-  container: AwilixContainer
+  container: AwilixContainer,
+  cache: Cache
 ): CommandHandler {
   assertExists(container, 'container')
+  assertExists(cache, 'cache')
 
   return async function run(cliArgs: any) {
     // we manually inject the run functions here (instead of through the provide function above) so that
@@ -35,6 +38,9 @@ export default function provideRun(
       const runLive = container.resolve<RunLive>("runLive")
       await runLive()
     }
+
+    // persist any cached blocks/txs/traces to disk
+    cache.save(true) // true = dont prune keys not used in this run
 
     // invoke process.exit() for short-lived functions, otherwise
     // a child process (i.e. python agent process) can prevent commandline from returning

--- a/cli/di.container.ts
+++ b/cli/di.container.ts
@@ -7,6 +7,7 @@ import shell from 'shelljs'
 import prompts from 'prompts'
 import { jsonc } from 'jsonc'
 import axios, { AxiosRequestConfig } from 'axios'
+import flatCache from 'flat-cache'
 import provideInit from "./commands/init"
 import provideRun from "./commands/run"
 import providePublish from "./commands/publish"
@@ -72,6 +73,7 @@ export default function configureContainer(commandName: CommandName, cliArgs: an
         throw new Error(`unable to parse cli package.json: ${e.message}`)
       }
     }).singleton(),
+    cache: asFunction((fortaKeystore: string) => flatCache.load('cli-cache', fortaKeystore)).singleton(),
 
     fortaKeystore: asValue(join(os.homedir(), ".forta")),
     getFortaConfig: asFunction(provideGetFortaConfig),

--- a/cli/utils/get.block.with.transactions.spec.ts
+++ b/cli/utils/get.block.with.transactions.spec.ts
@@ -6,52 +6,87 @@ describe("getBlockWithTransactions", () => {
   const mockEthersProvider = {
     send: jest.fn()
   } as any
+  const mockCache = {
+    getKey: jest.fn(),
+    setKey: jest.fn()
+  } as any
 
   const resetMocks = () => {
     mockEthersProvider.send.mockReset()
+    mockCache.getKey.mockReset()
+    mockCache.setKey.mockReset()
   }
 
   beforeAll(() => {
-    getBlockWithTransactions = provideGetBlockWithTransactions(mockEthersProvider)
+    getBlockWithTransactions = provideGetBlockWithTransactions(mockEthersProvider, mockCache)
   })
 
   beforeEach(() => {
     resetMocks()
   })
 
-  it("for integer block number, invokes eth_getBlockByNumber jsonrpc method and returns block", async () => {
+  it("for integer block number, returns cached block if it exists", async () => {
     const mockBlockNumber = 123
     const mockBlock = { hash: "0xabc", number: mockBlockNumber }
+    mockCache.getKey.mockReturnValueOnce(mockBlock)
+
+    const block = await getBlockWithTransactions(mockBlockNumber)
+
+    expect(block).toStrictEqual(mockBlock)
+    expect(mockCache.getKey).toHaveBeenCalledTimes(1)
+    expect(mockCache.getKey).toHaveBeenCalledWith(mockBlockNumber.toString())
+    expect(mockEthersProvider.send).toHaveBeenCalledTimes(0)
+    expect(mockCache.setKey).toHaveBeenCalledTimes(0)
+  })
+
+  it("for integer block number, invokes eth_getBlockByNumber jsonrpc method and returns block", async () => {
+    const mockBlockNumber = 123
+    const mockBlock = { hash: "0xaBc", number: mockBlockNumber }
     mockEthersProvider.send.mockReturnValueOnce(mockBlock)
 
     const block = await getBlockWithTransactions(mockBlockNumber)
 
     expect(block).toStrictEqual(mockBlock)
+    expect(mockCache.getKey).toHaveBeenCalledTimes(1)
+    expect(mockCache.getKey).toHaveBeenCalledWith(mockBlockNumber.toString())
     expect(mockEthersProvider.send).toHaveBeenCalledTimes(1)
     expect(mockEthersProvider.send).toHaveBeenCalledWith("eth_getBlockByNumber", [ethers.utils.hexValue(mockBlockNumber), true])
+    expect(mockCache.setKey).toHaveBeenCalledTimes(2)
+    expect(mockCache.setKey).toHaveBeenCalledWith(mockBlock.hash.toLowerCase(), mockBlock)
+    expect(mockCache.setKey).toHaveBeenCalledWith(mockBlock.number.toString(), mockBlock)
   })
 
   it("for string block number, invokes eth_getBlockByNumber jsonrpc method and returns block", async () => {
     const mockBlockNumber = "123"
-    const mockBlock = { hash: "0xabc", number: mockBlockNumber }
+    const mockBlock = { hash: "0xabC", number: mockBlockNumber }
     mockEthersProvider.send.mockReturnValueOnce(mockBlock)
 
     const block = await getBlockWithTransactions(mockBlockNumber)
 
     expect(block).toStrictEqual(mockBlock)
+    expect(mockCache.getKey).toHaveBeenCalledTimes(1)
+    expect(mockCache.getKey).toHaveBeenCalledWith(mockBlockNumber.toString())
     expect(mockEthersProvider.send).toHaveBeenCalledTimes(1)
     expect(mockEthersProvider.send).toHaveBeenCalledWith("eth_getBlockByNumber", [ethers.utils.hexValue(parseInt(mockBlockNumber)), true])
+    expect(mockCache.setKey).toHaveBeenCalledTimes(2)
+    expect(mockCache.setKey).toHaveBeenCalledWith(mockBlock.hash.toLowerCase(), mockBlock)
+    expect(mockCache.setKey).toHaveBeenCalledWith(mockBlock.number.toString(), mockBlock)
   })
 
   it("for string block hash, invokes eth_getBlockByHash jsonrpc method and returns block", async () => {
-    const mockBlockNumber = "0x123"
-    const mockBlock = { hash: "0xabc", number: mockBlockNumber }
+    const mockBlockHash = "0xAbc"
+    const mockBlock = { hash: mockBlockHash, number: 123 }
     mockEthersProvider.send.mockReturnValueOnce(mockBlock)
 
-    const block = await getBlockWithTransactions(mockBlockNumber)
+    const block = await getBlockWithTransactions(mockBlockHash)
 
     expect(block).toStrictEqual(mockBlock)
+    expect(mockCache.getKey).toHaveBeenCalledTimes(1)
+    expect(mockCache.getKey).toHaveBeenCalledWith(mockBlockHash.toLowerCase())
     expect(mockEthersProvider.send).toHaveBeenCalledTimes(1)
-    expect(mockEthersProvider.send).toHaveBeenCalledWith("eth_getBlockByHash", [ethers.utils.hexValue(mockBlockNumber), true])
+    expect(mockEthersProvider.send).toHaveBeenCalledWith("eth_getBlockByHash", [ethers.utils.hexValue(mockBlockHash), true])
+    expect(mockCache.setKey).toHaveBeenCalledTimes(2)
+    expect(mockCache.setKey).toHaveBeenCalledWith(mockBlock.hash.toLowerCase(), mockBlock)
+    expect(mockCache.setKey).toHaveBeenCalledWith(mockBlock.number.toString(), mockBlock)
   })
 })

--- a/cli/utils/get.block.with.transactions.ts
+++ b/cli/utils/get.block.with.transactions.ts
@@ -24,7 +24,7 @@ export default function provideGetBlockWithTransactions(
   assertExists(ethersProvider, 'ethersProvider')
   assertExists(cache, 'cache')
 
-  return async function provideGetBlockWithTransactions(blockHashOrNumber: string | number) {
+  return async function getBlockWithTransactions(blockHashOrNumber: string | number) {
     // check the cache first
     const cachedBlock = cache.getKey(blockHashOrNumber.toString().toLowerCase())
     if (cachedBlock) return cachedBlock

--- a/cli/utils/get.transaction.receipt.spec.ts
+++ b/cli/utils/get.transaction.receipt.spec.ts
@@ -5,9 +5,35 @@ describe("getTransactionReceipt", () => {
   const mockEthersProvider = {
     send: jest.fn()
   } as any
+  const mockCache = {
+    getKey: jest.fn(),
+    setKey: jest.fn()
+  } as any
+
+  const resetMocks = () => {
+    mockEthersProvider.send.mockReset()
+    mockCache.getKey.mockReset()
+    mockCache.setKey.mockReset()
+  }
 
   beforeAll(() => {
-    getTransactionReceipt = provideGetTransactionReceipt(mockEthersProvider)
+    getTransactionReceipt = provideGetTransactionReceipt(mockEthersProvider, mockCache)
+  })
+
+  beforeEach(() => resetMocks())
+
+  it("returns cached receipt if it exists", async () => {
+    const mockTxHash = "0x123Abc"
+    const mockReceipt = { hash: mockTxHash, blockNumber: 123 }
+    mockCache.getKey.mockReturnValueOnce(mockReceipt)
+
+    const receipt = await getTransactionReceipt(mockTxHash)
+
+    expect(receipt).toStrictEqual(mockReceipt)
+    expect(mockCache.getKey).toHaveBeenCalledTimes(1)
+    expect(mockCache.getKey).toHaveBeenCalledWith(mockTxHash.toLowerCase())
+    expect(mockEthersProvider.send).toHaveBeenCalledTimes(0)
+    expect(mockCache.setKey).toHaveBeenCalledTimes(0)
   })
 
   it("invokes eth_getTransactionReceipt jsonrpc method and returns receipt", async () => {
@@ -18,7 +44,11 @@ describe("getTransactionReceipt", () => {
     const receipt = await getTransactionReceipt(mockTxHash)
 
     expect(receipt).toStrictEqual(mockReceipt)
+    expect(mockCache.getKey).toHaveBeenCalledTimes(1)
+    expect(mockCache.getKey).toHaveBeenCalledWith(mockTxHash.toLowerCase())
     expect(mockEthersProvider.send).toHaveBeenCalledTimes(1)
     expect(mockEthersProvider.send).toHaveBeenCalledWith('eth_getTransactionReceipt', [mockTxHash])
+    expect(mockCache.setKey).toHaveBeenCalledTimes(1)
+    expect(mockCache.setKey).toHaveBeenCalledWith(mockTxHash.toLowerCase(), mockReceipt)
   })
 })

--- a/cli/utils/get.transaction.receipt.ts
+++ b/cli/utils/get.transaction.receipt.ts
@@ -26,7 +26,7 @@ export default function provideGetTransactionReceipt(
   assertExists(ethersProvider, 'ethersProvider')
   assertExists(cache, 'cache')
 
-  return async function provideGetTransactionReceipt(txHash: string) {
+  return async function getTransactionReceipt(txHash: string) {
     // check cache first
     const cachedReceipt = cache.getKey(txHash.toLowerCase())
     if (cachedReceipt) return cachedReceipt

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "forta-agent",
-  "version": "0.0.26",
+  "version": "0.0.33",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "forta-agent",
-      "version": "0.0.26",
+      "version": "0.0.33",
       "license": "MIT",
       "dependencies": {
         "@grpc/grpc-js": "^1.3.6",
@@ -14,6 +14,7 @@
         "awilix": "^4.3.4",
         "axios": "^0.21.1",
         "ethers": "^5.5.1",
+        "flat-cache": "^3.0.4",
         "form-data": "^4.0.0",
         "jsonc": "^2.0.0",
         "keythereum": "^1.2.0",
@@ -29,6 +30,7 @@
         "forta-agent": "dist/cli/index.js"
       },
       "devDependencies": {
+        "@types/flat-cache": "^2.0.0",
         "@types/jest": "^26.0.22",
         "@types/lodash": "^4.14.170",
         "@types/n-readlines": "^1.0.2",
@@ -1849,6 +1851,12 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/flat-cache": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/flat-cache/-/flat-cache-2.0.0.tgz",
+      "integrity": "sha512-fHeEsm9hvmZ+QHpw6Fkvf19KIhuqnYLU6vtWLjd5BsMd/qVi7iTkMioDZl0mQmfNRA1A6NwvhrSRNr9hGYZGww==",
+      "dev": true
+    },
     "node_modules/@types/glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
@@ -3655,6 +3663,23 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/flat-cache": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "dependencies": {
+        "flatted": "^3.1.0",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
+      "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw=="
     },
     "node_modules/follow-redirects": {
       "version": "1.14.1",
@@ -6914,7 +6939,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -9621,6 +9645,12 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/flat-cache": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/flat-cache/-/flat-cache-2.0.0.tgz",
+      "integrity": "sha512-fHeEsm9hvmZ+QHpw6Fkvf19KIhuqnYLU6vtWLjd5BsMd/qVi7iTkMioDZl0mQmfNRA1A6NwvhrSRNr9hGYZGww==",
+      "dev": true
+    },
     "@types/glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
@@ -11087,6 +11117,20 @@
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
       }
+    },
+    "flat-cache": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "requires": {
+        "flatted": "^3.1.0",
+        "rimraf": "^3.0.2"
+      }
+    },
+    "flatted": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
+      "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw=="
     },
     "follow-redirects": {
       "version": "1.14.1",
@@ -13661,7 +13705,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "awilix": "^4.3.4",
     "axios": "^0.21.1",
     "ethers": "^5.5.1",
+    "flat-cache": "^3.0.4",
     "form-data": "^4.0.0",
     "jsonc": "^2.0.0",
     "keythereum": "^1.2.0",
@@ -43,6 +44,7 @@
     "yargs": "^17.0.1"
   },
   "devDependencies": {
+    "@types/flat-cache": "^2.0.0",
     "@types/jest": "^26.0.22",
     "@types/lodash": "^4.14.170",
     "@types/n-readlines": "^1.0.2",


### PR DESCRIPTION
adds a disk caching layer to the `forta-agent run` command so that any fetched blocks, transactions, receipts and traces are stored on disk to speed up future execution