### PR TITLE
support proto private flag

### DIFF
--- a/cli/commands/run/server/agent.controller.js
+++ b/cli/commands/run/server/agent.controller.js
@@ -1,4 +1,8 @@
-const { BlockEvent, TransactionEvent } = require("../../../../sdk");
+const {
+  BlockEvent,
+  TransactionEvent,
+  isPrivateFindings,
+} = require("../../../../sdk");
 const { assertExists, formatAddress } = require("../../../utils");
 
 module.exports = class AgentController {
@@ -38,6 +42,7 @@ module.exports = class AgentController {
       metadata: {
         timestamp: new Date().toISOString(),
       },
+      private: isPrivateFindings(),
     });
   }
 
@@ -68,6 +73,7 @@ module.exports = class AgentController {
       metadata: {
         timestamp: new Date().toISOString(),
       },
+      private: isPrivateFindings(),
     });
   }
 
@@ -108,11 +114,7 @@ module.exports = class AgentController {
       uncles: block.uncles,
     };
 
-    return new BlockEvent(
-      type,
-      parseInt(network.chainId),
-      blok
-    );
+    return new BlockEvent(type, parseInt(network.chainId), blok);
   }
 
   createTransactionEventFromGrpcRequest(request) {

--- a/cli/commands/run/server/agent.controller.spec.ts
+++ b/cli/commands/run/server/agent.controller.spec.ts
@@ -192,6 +192,7 @@ describe("AgentController", () => {
         metadata: {
           timestamp: systemTime.toISOString(),
         },
+        private: false
       })
     })
 
@@ -208,6 +209,7 @@ describe("AgentController", () => {
         metadata: {
           timestamp: systemTime.toISOString(),
         },
+        private: false
       })
     })
 
@@ -227,6 +229,7 @@ describe("AgentController", () => {
         metadata: {
           timestamp: systemTime.toISOString(),
         },
+        private: false
       })
       expect(mockHandleBlock).toHaveBeenCalledTimes(1)
       const blockEvent: BlockEvent = mockHandleBlock.mock.calls[0][0]
@@ -287,6 +290,7 @@ describe("AgentController", () => {
         metadata: {
           timestamp: systemTime.toISOString(),
         },
+        private: false
       })
     })
 
@@ -303,6 +307,7 @@ describe("AgentController", () => {
         metadata: {
           timestamp: systemTime.toISOString(),
         },
+        private: false
       })
     })
 
@@ -321,6 +326,7 @@ describe("AgentController", () => {
         metadata: {
           timestamp: systemTime.toISOString(),
         },
+        private: false
       })
       expect(mockHandleTransaction).toHaveBeenCalledTimes(1)
       const txEvent: TransactionEvent = mockHandleTransaction.mock.calls[0][0]

--- a/cli/commands/run/server/agent.proto
+++ b/cli/commands/run/server/agent.proto
@@ -67,6 +67,7 @@ message Finding {
   string name = 6;
   string description = 7;
   string everestId = 8;
+  bool private = 9;
 }
 
 message EvaluateTxResponse {
@@ -76,6 +77,7 @@ message EvaluateTxResponse {
   map<string, string> metadata = 4;
   string timestamp = 5;
   uint32 latencyMs = 6;
+  bool private = 7;
 }
 
 message EvaluateBlockResponse {
@@ -85,12 +87,13 @@ message EvaluateBlockResponse {
   map<string, string> metadata = 4;
   string timestamp = 5;
   uint32 latencyMs = 6;
+  bool private = 7;
 }
 
 message BlockEvent {
   enum EventType {
     BLOCK = 0;
-    REORG = 1;
+    REORG = 1 [deprecated=true];
   }
   message Network {
     string chainId = 1;

--- a/sdk/index.ts
+++ b/sdk/index.ts
@@ -3,10 +3,19 @@ import { Finding, FindingSeverity, FindingType } from "./finding"
 import { BlockEvent } from "./block.event"
 import { Block } from "./block"
 import { TransactionEvent, TxEventBlock, LogDescription } from "./transaction.event"
-import { createBlockEvent, createTransactionEvent, getJsonRpcUrl, getEthersProvider, getEthersBatchProvider, keccak256 } from "./utils"
 import { Log, Receipt } from "./receipt"
 import { Trace, TraceAction, TraceResult } from "./trace"
 import { Transaction } from "./transaction"
+import { 
+  createBlockEvent, 
+  createTransactionEvent, 
+  getJsonRpcUrl, 
+  getEthersProvider, 
+  getEthersBatchProvider, 
+  keccak256,
+  setPrivateFindings,
+  isPrivateFindings
+} from "./utils"
 
 interface FortaConfig {
   agentId?: string
@@ -68,5 +77,7 @@ export {
   getEthersProvider,
   getEthersBatchProvider,
   ethers,
-  keccak256
+  keccak256,
+  setPrivateFindings,
+  isPrivateFindings
  }

--- a/sdk/utils.ts
+++ b/sdk/utils.ts
@@ -100,3 +100,12 @@ export const keccak256 = (str: string) => {
   hash.update(str)
   return `0x${hash.digest('hex')}`
 }
+
+let IS_PRIVATE_FINDINGS = false
+export const setPrivateFindings = (isPrivate: boolean) => {
+  IS_PRIVATE_FINDINGS = isPrivate
+}
+
+export const isPrivateFindings = () => {
+  return IS_PRIVATE_FINDINGS
+}


### PR DESCRIPTION
adding support for agent.proto `private` flag by exposing a `setPrivateFindings` method from the SDK. agents that want to make their findings private would invoke `setPrivateFindings(true)` somewhere in their initialization