### PR TITLE
🎨  Improve block processing

### DIFF
--- a/cli/di.container.ts
+++ b/cli/di.container.ts
@@ -159,6 +159,8 @@ export default function configureContainer(commandName: CommandName, cliArgs: an
     listKeyfiles: asFunction(provideListKeyfiles),
     addToIpfs: asFunction(provideAddToIpfs),
     appendToFile: asFunction(provideAppendToFile),
+    shouldContinue: asFunction(() =>  true).singleton(),
+
 
     getNetworkId: asFunction(provideGetNetworkId),
     getBlockWithTransactions: asFunction(provideGetBlockWithTransactions),


### PR DESCRIPTION
This change implements a `blockQueue` that forces the SDK to process blocks sequentially. It replaces the tests in run.live.spec.ts to accommodate this new change. 