### PR TITLE
add nocache option to run command

### DIFF
--- a/cli/commands/run/index.spec.ts
+++ b/cli/commands/run/index.spec.ts
@@ -104,7 +104,7 @@ describe("run", () => {
   })
 
   it("invokes runLive if no argument is provided", async () => {
-    const mockCliArgs = {}
+    const mockCliArgs = {nocache: ""}
     const mockRunLive = jest.fn()
     mockContainer.resolve.mockReturnValueOnce(mockRunLive)
 
@@ -114,8 +114,7 @@ describe("run", () => {
     expect(mockContainer.resolve).toHaveBeenCalledWith("runLive")
     expect(mockRunLive).toHaveBeenCalledTimes(1)
     expect(mockRunLive).toHaveBeenCalledWith()
-    expect(mockCache.save).toHaveBeenCalledTimes(1)
-    expect(mockCache.save).toHaveBeenCalledWith(true)
+    expect(mockCache.save).toHaveBeenCalledTimes(0)
     expect(mockExit).toHaveBeenCalledTimes(0)
   })
 })

--- a/cli/commands/run/index.ts
+++ b/cli/commands/run/index.ts
@@ -39,8 +39,10 @@ export default function provideRun(
       await runLive()
     }
 
-    // persist any cached blocks/txs/traces to disk
-    cache.save(true) // true = dont prune keys not used in this run
+    if (!("nocache" in cliArgs)) {
+      // persist any cached blocks/txs/traces to disk
+      cache.save(true) // true = dont prune keys not used in this run
+    }
 
     // invoke process.exit() for short-lived functions, otherwise
     // a child process (i.e. python agent process) can prevent commandline from returning

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -46,6 +46,9 @@ yargs
       }).option('config', {
         description: 'Specify a config file (default: forta.config.json)',
         type: 'string',
+      }).option('nocache', {
+        description: 'Disables writing to the cache (but reads are still enabled)',
+        type: 'string'
       })
     },
     (cliArgs: any) => executeCommand("run", cliArgs)


### PR DESCRIPTION
adds a `--nocache` option to the `forta-agent run` command that disables writing to the cache (but reads are still enabled)