### PR TITLE
dont throw jsonRpcUrl error in tests

### DIFF
--- a/python-sdk/src/forta_agent/utils.py
+++ b/python-sdk/src/forta_agent/utils.py
@@ -35,11 +35,13 @@ def get_json_rpc_url():
         return f'http://{os.environ["JSON_RPC_HOST"]}{":"+os.environ["JSON_RPC_PORT"] if "JSON_RPC_PORT" in os.environ else ""}'
 
     config = get_forta_config()
+    if os.environ.get('PYTHON_ENV') == "test":  # dont throw errors when running tests
+        return config.get("jsonRpcUrl")
     if "jsonRpcUrl" not in config:
         raise Exception("no jsonRpcUrl found")
     if not str(config.get("jsonRpcUrl")).startswith("http"):
         raise Exception("jsonRpcUrl must begin with http(s)")
-    return config["jsonRpcUrl"]
+    return config.get("jsonRpcUrl")
 
 
 def create_block_event(dict):

--- a/sdk/utils.ts
+++ b/sdk/utils.ts
@@ -44,6 +44,7 @@ export const getJsonRpcUrl = () => {
   
   // else, use the rpc url from forta.config.json
   const { jsonRpcUrl } = getFortaConfig()
+  if (process.env.NODE_ENV === "test") return jsonRpcUrl // dont throw errors when running tests
   if (!jsonRpcUrl) throw new Error('no jsonRpcUrl found')
   if (!jsonRpcUrl.startsWith("http")) throw new Error('jsonRpcUrl must begin with http(s)')
   return jsonRpcUrl

--- a/starter-project/py/pytest.ini
+++ b/starter-project/py/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+env =
+    PYTHON_ENV=test

--- a/starter-project/py/requirements_dev.txt
+++ b/starter-project/py/requirements_dev.txt
@@ -1,2 +1,3 @@
 -r requirements.txt
 pytest==6.2.5
+pytest-env==0.6.2


### PR DESCRIPTION
dont throw error if jsonRpcUrl not provided when running jest/pytest unit tests