### PR TITLE
Expose cli commands

### DIFF
--- a/cli/commands/disable/index.spec.ts
+++ b/cli/commands/disable/index.spec.ts
@@ -33,7 +33,7 @@ describe("disable", () => {
     mockAgentRegistry.agentExists.mockReturnValueOnce(false)
 
     try {
-      await disable({})
+      await disable()
     } catch (e) {
       expect(e.message).toBe(`agent id ${mockAgentId} does not exist`)
     }
@@ -46,7 +46,7 @@ describe("disable", () => {
     mockAgentRegistry.agentExists.mockReturnValueOnce(true)
     mockAgentRegistry.isEnabled.mockReturnValueOnce(false)
 
-    await disable({})
+    await disable()
 
     expect(mockAgentRegistry.agentExists).toHaveBeenCalledTimes(1)
     expect(mockAgentRegistry.agentExists).toHaveBeenCalledWith(mockAgentId)
@@ -63,7 +63,7 @@ describe("disable", () => {
     const mockPrivateKey = "0x4567"
     mockGetCredentials.mockReturnValueOnce({ privateKey: mockPrivateKey })
 
-    await disable({})
+    await disable()
 
     expect(mockAgentRegistry.agentExists).toHaveBeenCalledTimes(1)
     expect(mockAgentRegistry.agentExists).toHaveBeenCalledWith(mockAgentId)

--- a/cli/commands/disable/index.ts
+++ b/cli/commands/disable/index.ts
@@ -9,14 +9,14 @@ export default function provideDisable(
   appendToFile: AppendToFile,
   getCredentials: GetCredentials,
   agentRegistry: AgentRegistry,
-  agentId: string
+  agentId: string,
 ): CommandHandler {
   assertExists(appendToFile, 'appendToFile')
   assertExists(getCredentials, 'getCredentials')
   assertExists(agentRegistry, 'agentRegistry')
   assertIsNonEmptyString(agentId, 'agentId')
 
-  return async function disable(cliArgs: any) {
+  return async function disable() {
     const agentExists = await agentRegistry.agentExists(agentId)
     if (!agentExists) {
       throw new Error(`agent id ${agentId} does not exist`)

--- a/cli/commands/enable/index.spec.ts
+++ b/cli/commands/enable/index.spec.ts
@@ -33,7 +33,7 @@ describe("enable", () => {
     mockAgentRegistry.agentExists.mockReturnValueOnce(false)
 
     try {
-      await enable({})
+      await enable()
     } catch (e) {
       expect(e.message).toBe(`agent id ${mockAgentId} does not exist`)
     }
@@ -46,7 +46,7 @@ describe("enable", () => {
     mockAgentRegistry.agentExists.mockReturnValueOnce(true)
     mockAgentRegistry.isEnabled.mockReturnValueOnce(true)
 
-    await enable({})
+    await enable()
 
     expect(mockAgentRegistry.agentExists).toHaveBeenCalledTimes(1)
     expect(mockAgentRegistry.agentExists).toHaveBeenCalledWith(mockAgentId)
@@ -63,7 +63,7 @@ describe("enable", () => {
     const mockPrivateKey = "0x4567"
     mockGetCredentials.mockReturnValueOnce({ privateKey: mockPrivateKey })
 
-    await enable({})
+    await enable()
 
     expect(mockAgentRegistry.agentExists).toHaveBeenCalledTimes(1)
     expect(mockAgentRegistry.agentExists).toHaveBeenCalledWith(mockAgentId)

--- a/cli/commands/enable/index.ts
+++ b/cli/commands/enable/index.ts
@@ -16,7 +16,7 @@ export default function provideEnable(
   assertExists(agentRegistry, 'agentRegistry')
   assertIsNonEmptyString(agentId, 'agentId')
 
-  return async function enable(cliArgs: any) {
+  return async function enable() {
     const agentExists = await agentRegistry.agentExists(agentId)
     if (!agentExists) {
       throw new Error(`agent id ${agentId} does not exist`)

--- a/cli/commands/init/index.spec.ts
+++ b/cli/commands/init/index.spec.ts
@@ -19,7 +19,8 @@ describe("init", () => {
   const mockConfigFilename = "forta.config.json"
   const mockListKeyfiles = jest.fn()
   const mockCreateKeyfile = jest.fn()
-  const mockCliArgs = {}
+  const mockContextPath = "/path/to/agent"
+  const mockArgs = {}
   const starterProjectPath = `${join(__dirname, '..', '..', '..', 'starter-project')}`
 
   const resetMocks = () => {
@@ -36,7 +37,7 @@ describe("init", () => {
 
   beforeAll(() => {
     init = provideInit(
-      mockShell, mockPrompt, mockFilesystem, mockFortaKeystore, mockConfigFilename, mockListKeyfiles, mockCreateKeyfile)
+      mockShell, mockPrompt, mockFilesystem, mockFortaKeystore, mockConfigFilename, mockListKeyfiles, mockCreateKeyfile, mockContextPath, mockArgs)
   })
 
   beforeEach(() => resetMocks())
@@ -45,7 +46,7 @@ describe("init", () => {
     mockShell.ls.mockReturnValueOnce(['file1', 'file2'])
     mockPrompt.mockReturnValueOnce({ proceed: 'no' })
 
-    await init(mockCliArgs)
+    await init()
 
     expect(mockShell.ls).toHaveBeenCalledTimes(1)
     expect(mockPrompt).toHaveBeenCalledTimes(1)
@@ -66,7 +67,7 @@ describe("init", () => {
     mockShell.cp.mockReturnValueOnce(copyProjectResult)
 
     try {
-      await init(mockCliArgs)
+      await init()
     } catch (e) {
       expect(e.message).toEqual(`error copying starter-project folder: ${copyProjectResult.stderr}`)
     }
@@ -86,12 +87,14 @@ describe("init", () => {
       .mockReturnValueOnce(copyJsTsResult)
 
     try {
-      await init(mockCliArgs)
+      await init()
     } catch (e) {
       expect(e.message).toEqual(`error unpacking js folder: ${copyJsTsResult.stderr}`)
     }
     try {
-      await init({ ...mockCliArgs, typescript: true })
+      init = provideInit(
+        mockShell, mockPrompt, mockFilesystem, mockFortaKeystore, mockConfigFilename, mockListKeyfiles, mockCreateKeyfile, mockContextPath, { ...mockArgs, typescript: true })
+      await init()
     } catch (e) {
       expect(e.message).toEqual(`error unpacking ts folder: ${copyJsTsResult.stderr}`)
     }
@@ -113,7 +116,7 @@ describe("init", () => {
     mockShell.mv.mockReturnValueOnce(renameGitignoreResult)
 
     try {
-      await init(mockCliArgs)
+      await init()
     } catch (e) {
       expect(e.message).toEqual(`error renaming gitignore file: ${renameGitignoreResult.stderr}`)
     }
@@ -135,7 +138,7 @@ describe("init", () => {
     mockShell.rm.mockReturnValueOnce(removeUnusedResult)
 
     try {
-      await init(mockCliArgs)
+      await init()
     } catch (e) {
       expect(e.message).toEqual(`error cleaning up files: ${removeUnusedResult.stderr}`)
     }
@@ -161,7 +164,7 @@ describe("init", () => {
     mockShell.mkdir.mockReturnValueOnce(createKeystoreResult)
 
     try {
-      await init(mockCliArgs)
+      await init()
     } catch (e) {
       expect(e.message).toEqual(`error creating keystore folder ${mockFortaKeystore}: ${createKeystoreResult.stderr}`)
     }
@@ -192,7 +195,7 @@ describe("init", () => {
     mockShell.cp.mockReturnValueOnce(copyConfigResult)
 
     try {
-      await init(mockCliArgs)
+      await init()
     } catch (e) {
       expect(e.message).toEqual(`error creating ${mockConfigFilename}: ${copyConfigResult.stderr}`)
     }
@@ -222,7 +225,7 @@ describe("init", () => {
     mockPrompt.mockReturnValueOnce({ password })
     mockFilesystem.existsSync.mockReturnValueOnce(true).mockReturnValueOnce(true)
 
-    await init(mockCliArgs)
+    await init()
 
     expect(mockShell.ls).toHaveBeenCalledTimes(1)
     expect(mockShell.cp).toHaveBeenCalledTimes(2)
@@ -254,7 +257,7 @@ describe("init", () => {
     mockShell.rm.mockReturnValueOnce(removeUnusedResult)
     mockFilesystem.existsSync.mockReturnValueOnce(true).mockReturnValueOnce(true)
 
-    await init(mockCliArgs)
+    await init()
 
     expect(mockShell.ls).toHaveBeenCalledTimes(1)
     expect(mockShell.cp).toHaveBeenCalledTimes(2)

--- a/cli/commands/init/index.ts
+++ b/cli/commands/init/index.ts
@@ -44,7 +44,7 @@ export default function provideInit(
       const { proceed } = await prompt({
         type: 'text',
         name: 'proceed',
-        message: `The current directory is not empty and files could be overwritten. Are you sure you want to initialize? (type 'yes' to proceed)`
+        message: `The directory ${contextPath} is not empty and files could be overwritten. Are you sure you want to initialize? (type 'yes' to proceed)`
       })
       if (proceed !== 'yes') {
         console.log('aborting initialization')
@@ -54,7 +54,7 @@ export default function provideInit(
 
     const isTypescript = !!args.typescript
     const isPython = !!args.python
-    console.log(`initializing ${isPython ? "Python" : isTypescript ? "Typescript" : "Javascript"} Forta Agent...`)
+    console.log(`Initializing ${isPython ? "Python" : isTypescript ? "Typescript" : "Javascript"} Forta Agent...`)
     const starterProjectPath = `${join(__dirname, '..', '..', '..', 'starter-project')}`
     // copy files from starter-project to current directory
     const copyProjectResult = shell.cp('-r', [`${starterProjectPath}/*`, `${starterProjectPath}/.*`], '.')
@@ -78,11 +78,11 @@ export default function provideInit(
     
     // create global forta.config.json if doesnt already exist
     if (!filesystem.existsSync(join(fortaKeystore, configFilename))) {
-      console.log(`creating ${configFilename}...`)
+      console.log(`Creating ${configFilename}...`)
       const copyConfigResult = shell.cp(join(__dirname, configFilename), fortaKeystore)
       assertShellResult(copyConfigResult, `error creating ${configFilename}`)
     } else {
-      console.log(`found existing ${configFilename} in ${fortaKeystore}`)
+      console.log(`Found existing ${configFilename} in ${fortaKeystore}`)
     }
 
     // create keyfile if one doesnt already exist
@@ -96,11 +96,11 @@ export default function provideInit(
       })
       await createKeyfile(password)
     } else {
-      console.log(`found existing keyfile ${keyfiles[0]} in ${fortaKeystore}`)
+      console.log(`Found existing keyfile ${keyfiles[0]} in ${fortaKeystore}`)
     }
 
     // run npm install in the project folder to initialize dependencies
-    console.log('running npm install...')
+    console.log('Running npm install...')
     const npmInstallResult = shell.exec(`npm install`)
     assertShellResult(npmInstallResult, `error installing npm dependencies`)
     

--- a/cli/commands/init/index.ts
+++ b/cli/commands/init/index.ts
@@ -103,11 +103,5 @@ export default function provideInit(
     console.log('running npm install...')
     const npmInstallResult = shell.exec(`npm install`)
     assertShellResult(npmInstallResult, `error installing npm dependencies`)
-
-    if (isTypescript) {
-      console.log(`compiling Typescript...`)
-      const compileTsResult = shell.exec(`npm run build`)
-      assertShellResult(compileTsResult, `error compiling Typescript`)
-    }
   } 
 }

--- a/cli/commands/keyfile/index.spec.ts
+++ b/cli/commands/keyfile/index.spec.ts
@@ -16,7 +16,7 @@ describe("keyfile", () => {
     mockGetKeyfile.mockReturnValueOnce({ path: mockPath })
     mockGetJsonFile.mockReturnValueOnce({ address: mockAddress })
 
-    await keyfile({})
+    await keyfile()
 
     expect(mockGetKeyfile).toHaveBeenCalledTimes(1)
     expect(mockGetKeyfile).toHaveBeenCalledWith()

--- a/cli/commands/publish/index.spec.ts
+++ b/cli/commands/publish/index.spec.ts
@@ -20,7 +20,7 @@ describe("publish", () => {
     const mockManifestRef = "def456"
     mockUploadManifest.mockReturnValueOnce(mockManifestRef)
 
-    await publish({})
+    await publish()
 
     expect(mockUploadImage).toHaveBeenCalledTimes(1)
     expect(mockUploadImage).toHaveBeenCalledWith()

--- a/cli/commands/publish/index.ts
+++ b/cli/commands/publish/index.ts
@@ -16,7 +16,7 @@ export default function providePublish(
   assertExists(uploadManifest, 'uploadManifest')
   assertExists(pushToRegistry, 'pushToRegistry')
 
-  return async function publish(cliArgs: any) {
+  return async function publish() {
     const imageReference = await uploadImage()
     const { privateKey } = await getCredentials()
     const manifestReference = await uploadManifest(imageReference, privateKey)

--- a/cli/commands/push/index.spec.ts
+++ b/cli/commands/push/index.spec.ts
@@ -16,7 +16,7 @@ describe("push", () => {
     const mockImageRef = "someImageRef"
     mockUploadImage.mockReturnValueOnce(mockImageRef)
 
-    await push({})
+    await push()
 
     expect(mockUploadImage).toHaveBeenCalledTimes(1)
     expect(mockUploadImage).toHaveBeenCalledWith()

--- a/cli/commands/push/index.ts
+++ b/cli/commands/push/index.ts
@@ -10,7 +10,7 @@ export default function providePush(
   assertExists(uploadImage, 'uploadImage')
   assertExists(appendToFile, 'appendToFile')
 
-  return async function push(cliArgs: any) {
+  return async function push() {
     const imageReference = await uploadImage()
 
     const logMessage = `successfully pushed image with reference ${imageReference}`

--- a/cli/commands/run/index.spec.ts
+++ b/cli/commands/run/index.spec.ts
@@ -17,10 +17,6 @@ describe("run", () => {
     mockExit.mockReset()
   }
 
-  beforeAll(() => {
-    run = provideRun(mockContainer, mockCache)
-  })
-
   beforeEach(() => resetMocks())
 
   it("invokes runTransaction if --tx argument is provided", async () => {
@@ -28,7 +24,8 @@ describe("run", () => {
     const mockRunTransaction = jest.fn()
     mockContainer.resolve.mockReturnValueOnce(mockRunTransaction)
 
-    await run(mockCliArgs)
+    run = provideRun(mockContainer, mockCache, mockCliArgs)
+    await run()
 
     expect(mockContainer.resolve).toHaveBeenCalledTimes(1)
     expect(mockContainer.resolve).toHaveBeenCalledWith("runTransaction")
@@ -44,7 +41,8 @@ describe("run", () => {
     const mockRunBlock = jest.fn()
     mockContainer.resolve.mockReturnValueOnce(mockRunBlock)
 
-    await run(mockCliArgs)
+    run = provideRun(mockContainer, mockCache, mockCliArgs)
+    await run()
 
     expect(mockContainer.resolve).toHaveBeenCalledTimes(1)
     expect(mockContainer.resolve).toHaveBeenCalledWith("runBlock")
@@ -60,7 +58,8 @@ describe("run", () => {
     const mockRunBlockRange = jest.fn()
     mockContainer.resolve.mockReturnValueOnce(mockRunBlockRange)
 
-    await run(mockCliArgs)
+    run = provideRun(mockContainer, mockCache, mockCliArgs)
+    await run()
 
     expect(mockContainer.resolve).toHaveBeenCalledTimes(1)
     expect(mockContainer.resolve).toHaveBeenCalledWith("runBlockRange")
@@ -76,7 +75,8 @@ describe("run", () => {
     const mockRunFile = jest.fn()
     mockContainer.resolve.mockReturnValueOnce(mockRunFile)
 
-    await run(mockCliArgs)
+    run = provideRun(mockContainer, mockCache, mockCliArgs)
+    await run()
 
     expect(mockContainer.resolve).toHaveBeenCalledTimes(1)
     expect(mockContainer.resolve).toHaveBeenCalledWith("runFile")
@@ -92,7 +92,8 @@ describe("run", () => {
     const mockRunProdServer = jest.fn()
     mockContainer.resolve.mockReturnValueOnce(mockRunProdServer)
 
-    await run(mockCliArgs)
+    run = provideRun(mockContainer, mockCache, mockCliArgs)
+    await run()
 
     expect(mockContainer.resolve).toHaveBeenCalledTimes(1)
     expect(mockContainer.resolve).toHaveBeenCalledWith("runProdServer")
@@ -108,7 +109,8 @@ describe("run", () => {
     const mockRunLive = jest.fn()
     mockContainer.resolve.mockReturnValueOnce(mockRunLive)
 
-    await run(mockCliArgs)
+    run = provideRun(mockContainer, mockCache, mockCliArgs)
+    await run()
 
     expect(mockContainer.resolve).toHaveBeenCalledTimes(1)
     expect(mockContainer.resolve).toHaveBeenCalledWith("runLive")

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -2,14 +2,14 @@
 import yargs, { Argv } from 'yargs';
 import configureContainer from './di.container';
 
-export type CommandName = "init" | "run" | "publish" | "push" | "disable" | "enable" | "keyfile"
-export type CommandHandler = (args: any) => Promise<void>
+type CommandName = "init" | "run" | "publish" | "push" | "disable" | "enable" | "keyfile"
+export type CommandHandler = (args?: any) => Promise<void>
 
-async function executeCommand(commandName: CommandName, cliArgs: any) {
+async function executeCommand(cliCommandName: CommandName, cliArgs: any) {
   try {
-    const diContainer = configureContainer(commandName, cliArgs);
-    const command = diContainer.resolve<CommandHandler>(commandName)
-    await command(cliArgs)
+    const diContainer = configureContainer({ ...cliArgs, cliCommandName });
+    const command = diContainer.resolve<CommandHandler>(cliCommandName)
+    await command()
   } catch (e) {
     console.error(`ERROR: ${e}`)
     process.exit()

--- a/cli/utils/get.forta.config.spec.ts
+++ b/cli/utils/get.forta.config.spec.ts
@@ -3,7 +3,6 @@ import provideGetFortaConfig, { GetFortaConfig } from "./get.forta.config"
 
 describe("getFortaConfig", () => {
   let getFortaConfig: GetFortaConfig
-  const mockCommandName = "run"
   const mockFilesystem = {
     existsSync: jest.fn()
   } as any
@@ -12,6 +11,7 @@ describe("getFortaConfig", () => {
   const mockLocalConfigFilename = "local.forta.config.json"
   const mockFortaKeystore = "/path/to/keystore"
   const mockGetJsonFile = jest.fn()
+  const mockContextPath = "/path/to/agent"
 
   const resetMocks = () => {
     mockFilesystem.existsSync.mockReset()
@@ -20,7 +20,7 @@ describe("getFortaConfig", () => {
 
   beforeAll(() => {
     getFortaConfig = provideGetFortaConfig(
-      mockCommandName, mockFilesystem, mockIsProduction, mockConfigFilename, mockLocalConfigFilename, mockFortaKeystore, mockGetJsonFile
+      mockFilesystem, mockIsProduction, mockConfigFilename, mockLocalConfigFilename, mockFortaKeystore, mockGetJsonFile, mockContextPath
     )
   })
 
@@ -51,8 +51,9 @@ describe("getFortaConfig", () => {
   })
 
   it("returns empty config if commandName is init", () => {
+    mockFilesystem.existsSync.mockReturnValue(false)
     const getFortaConfig = provideGetFortaConfig(
-      "init", mockFilesystem, mockIsProduction, mockConfigFilename, mockLocalConfigFilename, mockFortaKeystore, mockGetJsonFile
+      mockFilesystem, mockIsProduction, mockConfigFilename, mockLocalConfigFilename, mockFortaKeystore, mockGetJsonFile, mockContextPath
     )
 
     const config = getFortaConfig()
@@ -62,7 +63,7 @@ describe("getFortaConfig", () => {
 
   it("returns empty config if isProduction is true", () => {
     const getFortaConfig = provideGetFortaConfig(
-      mockCommandName, mockFilesystem, true, mockConfigFilename, mockLocalConfigFilename, mockFortaKeystore, mockGetJsonFile
+      mockFilesystem, true, mockConfigFilename, mockLocalConfigFilename, mockFortaKeystore, mockGetJsonFile, mockContextPath
     )
 
     const config = getFortaConfig()
@@ -78,7 +79,7 @@ describe("getFortaConfig", () => {
     expect(config).toStrictEqual({})
     expect(mockFilesystem.existsSync).toHaveBeenCalledTimes(2)
     expect(mockFilesystem.existsSync).toHaveBeenNthCalledWith(1, join(mockFortaKeystore, mockConfigFilename))
-    expect(mockFilesystem.existsSync).toHaveBeenNthCalledWith(2, join(process.cwd(), mockLocalConfigFilename))
+    expect(mockFilesystem.existsSync).toHaveBeenNthCalledWith(2, join(mockContextPath, mockLocalConfigFilename))
   })
 
   it("returns combined global and local config", () => {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "forta-agent": "./dist/cli/index.js"
   },
   "scripts": {
+    "build": "npm run js:build",
     "js:build": "tsc --p ./tsconfig.build.json && cp -r ./starter-project ./dist && cp ./cli/commands/init/forta.config.json ./dist/cli/commands/init/forta.config.json && cp ./cli/commands/run/server/agent.proto ./dist/cli/commands/run/server/agent.proto",
     "js:publish": "npm run js:build && npm publish",
     "js:publish:local": "npm link",

--- a/sdk/index.ts
+++ b/sdk/index.ts
@@ -16,7 +16,15 @@ import {
   setPrivateFindings,
   isPrivateFindings
 } from "./utils"
-import configureContainer from '../cli/di.container';
+import awilixConfigureContainer from '../cli/di.container';
+
+interface DiContainer {
+  resolve<T>(key: string): T
+}
+type ConfigureContainer = (args: object) => DiContainer
+const configureContainer: ConfigureContainer = (args: object = {}) => {
+  return awilixConfigureContainer(args)
+}
 
 interface FortaConfig {
   agentId?: string

--- a/sdk/index.ts
+++ b/sdk/index.ts
@@ -16,6 +16,7 @@ import {
   setPrivateFindings,
   isPrivateFindings
 } from "./utils"
+import configureContainer from '../cli/di.container';
 
 interface FortaConfig {
   agentId?: string
@@ -80,5 +81,6 @@ export {
   ethers,
   keccak256,
   setPrivateFindings,
-  isPrivateFindings
+  isPrivateFindings,
+  configureContainer
  }


### PR DESCRIPTION
the following changes are to support the development of the new Hardhat plugin:
- exposes a `configureContainer` method which returns a dependency injection container that can be used to invoke CLI functionality
- defines a `contextPath` variable which can be used to point to different agent folders (previously always assumed current working directory)
- updates implementation of run.live to be correctly `await`able (was causing issues when invoking from Hardhat CLI)
- updates `init` command to create agent folder if it doesnt exist already and also to execute `npm install`