### PR TITLE
Update agent proto

### DIFF
--- a/cli/commands/run/server/agent.controller.js
+++ b/cli/commands/run/server/agent.controller.js
@@ -122,10 +122,11 @@ module.exports = class AgentController {
       type,
       network,
       transaction: tx,
-      receipt: rcpt,
+      logs: lgs,
       traces: trcs,
       addresses,
       block,
+      contractAddress
     } = request.event;
 
     const transaction = {
@@ -142,31 +143,17 @@ module.exports = class AgentController {
       v: tx.v,
     };
 
-    const receipt = {
-      status: rcpt.status === "0x1",
-      root: rcpt.root,
-      gasUsed: rcpt.gasUsed,
-      cumulativeGasUsed: rcpt.cumulativeGasUsed,
-      logsBloom: rcpt.logsBloom,
-      logs: rcpt.logs.map((log) => ({
-        address: formatAddress(log.address),
-        topics: log.topics,
-        data: log.data,
-        logIndex: parseInt(log.logIndex),
-        blockNumber: parseInt(log.blockNumber),
-        blockHash: log.blockHash,
-        transactionIndex: parseInt(log.transactionIndex),
-        transactionHash: log.transactionHash,
-        removed: log.removed,
-      })),
-      contractAddress: rcpt.contractAddress
-        ? formatAddress(rcpt.contractAddress)
-        : null,
-      blockNumber: parseInt(rcpt.blockNumber),
-      blockHash: rcpt.blockHash,
-      transactionIndex: parseInt(rcpt.transactionIndex),
-      transactionHash: rcpt.transactionHash,
-    };
+    const logs = lgs.map((log) => ({
+      address: formatAddress(log.address),
+      topics: log.topics,
+      data: log.data,
+      logIndex: parseInt(log.logIndex),
+      blockNumber: parseInt(log.blockNumber),
+      blockHash: log.blockHash,
+      transactionIndex: parseInt(log.transactionIndex),
+      transactionHash: log.transactionHash,
+      removed: log.removed,
+    }))
 
     const traces = !trcs
       ? []
@@ -208,10 +195,11 @@ module.exports = class AgentController {
       type,
       parseInt(network.chainId),
       transaction,
-      receipt,
       traces,
       addresses,
-      blok
+      blok,
+      logs,
+      contractAddress
     );
   }
 };

--- a/cli/commands/run/server/agent.controller.js
+++ b/cli/commands/run/server/agent.controller.js
@@ -199,7 +199,7 @@ module.exports = class AgentController {
       addresses,
       blok,
       logs,
-      contractAddress
+      formatAddress(contractAddress)
     );
   }
 };

--- a/cli/commands/run/server/agent.controller.spec.ts
+++ b/cli/commands/run/server/agent.controller.spec.ts
@@ -68,29 +68,17 @@ describe("AgentController", () => {
           "v": "0x0",
           "value": "400000000000000000"
         },
-        receipt: {
-          "root": "123abc",
-          "blockHash": "0x550bf22138e7cd31602ecc180fac4e1d719ac52cfad41c8320078683a3b90859",
+        logs: [{
+          "address": "0xB9f7bc0Ed37b821A34bFD508059c75460d6EFB37",
+          "topics": ["topic1"],
+          "data": "0xdata",
+          "logIndex": "1",
           "blockNumber": "13309526",
-          "contractAddress": "0x351d579AC59a1ea76afdedf567becc3518ee5deb",
-          "cumulativeGasUsed": "634772",
-          "gasUsed": "634772",
-          "logs": [{
-            "address": "0xB9f7bc0Ed37b821A34bFD508059c75460d6EFB37",
-            "topics": ["topic1"],
-            "data": "0xdata",
-            "logIndex": "1",
-            "blockNumber": "13309526",
-            "blockHash": "0x550bf22138e7cd31602ecc180fac4e1d719ac52cfad41c8320078683a3b90859",
-            "transactionIndex": "1",
-            "transactionHash": "0xfadb14c4d6bc7985583f6aded4d64bd0e071010ff4c29ab341a357550147fb28",
-            "removed": false
-          }],
-          "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-          "status": "0x0",
+          "blockHash": "0x550bf22138e7cd31602ecc180fac4e1d719ac52cfad41c8320078683a3b90859",
+          "transactionIndex": "1",
           "transactionHash": "0xfadb14c4d6bc7985583f6aded4d64bd0e071010ff4c29ab341a357550147fb28",
-          "transactionIndex": "0",
-        },
+          "removed": false
+        }],
         traces: [{
           "blockHash": "0x550bf22138e7cd31602ecc180fac4e1d719ac52cfad41c8320078683a3b90859",
           "blockNumber": 13309526,
@@ -347,14 +335,8 @@ describe("AgentController", () => {
         s: grpcTx.s,
         v: grpcTx.v,
       })
-      const grpcReceipt = mockTxRequest.request.event.receipt
-      expect(txEvent.receipt).toStrictEqual({
-        status: false,
-        root: grpcReceipt.root,
-        gasUsed: grpcReceipt.gasUsed,
-        cumulativeGasUsed: grpcReceipt.cumulativeGasUsed,
-        logsBloom: grpcReceipt.logsBloom,
-        logs: grpcReceipt.logs.map((log) => ({
+      const grpcLogs = mockTxRequest.request.event.logs
+      expect(txEvent.logs).toStrictEqual(grpcLogs.map(log => ({
           address: formatAddress(log.address),
           topics: log.topics,
           data: log.data,
@@ -364,13 +346,8 @@ describe("AgentController", () => {
           transactionIndex: parseInt(log.transactionIndex),
           transactionHash: log.transactionHash,
           removed: log.removed,
-        })),
-        contractAddress: formatAddress(grpcReceipt.contractAddress),
-        blockNumber: parseInt(grpcReceipt.blockNumber),
-        blockHash: grpcReceipt.blockHash,
-        transactionIndex: parseInt(grpcReceipt.transactionIndex),
-        transactionHash: grpcReceipt.transactionHash,
-      })
+        }))
+      )
       const grpcTraces = mockTxRequest.request.event.traces
       expect(txEvent.traces).toStrictEqual(grpcTraces.map((trace) => ({
         action: {

--- a/cli/commands/run/server/agent.controller.spec.ts
+++ b/cli/commands/run/server/agent.controller.spec.ts
@@ -113,7 +113,8 @@ describe("AgentController", () => {
           "blockHash": "0x550bf22138e7cd31602ecc180fac4e1d719ac52cfad41c8320078683a3b90859",
           "blockNumber": "13309526",
           "blockTimestamp": "1632768366"
-        }
+        },
+        contractAddress: "0xABcD14c4d6bc7985583f6aded4d64bd0e071010ff4c29ab341a357550147eF12"
       }
     }
   })
@@ -384,6 +385,7 @@ describe("AgentController", () => {
         number: parseInt(grpcBlock.blockNumber),
         timestamp: parseInt(grpcBlock.blockTimestamp),
       })
+      expect(txEvent.contractAddress).toStrictEqual(formatAddress(mockTxRequest.request.event.contractAddress))
     })
   })
 })

--- a/cli/commands/run/server/agent.proto
+++ b/cli/commands/run/server/agent.proto
@@ -221,9 +221,12 @@ message TransactionEvent {
 
   EventType type = 1;
   EthTransaction transaction = 2;
-  EthReceipt receipt = 3;
+  EthReceipt receipt = 3 [deprecated=true];
   Network network = 4;
   repeated Trace traces = 5;
   map<string, bool> addresses = 6;
   EthBlock block = 7;
+  repeated Log logs = 8;
+  bool isContractDeployment = 9;
+  string contractAddress = 10;
 }

--- a/cli/di.container.ts
+++ b/cli/di.container.ts
@@ -47,6 +47,7 @@ import provideGetKeyfile from './utils/get.keyfile'
 import provideInitKeystore from './utils/init.keystore'
 import provideInitKeyfile from './utils/init.keyfile'
 import provideInitConfig from './utils/init.config'
+import provideGetLogsForBlock from './utils/get.logs.for.block'
 
 export default function configureContainer(args: any = {}) {
   const container = createContainer({ injectionMode: InjectionMode.CLASSIC });
@@ -181,6 +182,7 @@ export default function configureContainer(args: any = {}) {
     getNetworkId: asFunction(provideGetNetworkId),
     getBlockWithTransactions: asFunction(provideGetBlockWithTransactions),
     getTransactionReceipt: asFunction(provideGetTransactionReceipt),
+    getLogsForBlock: asFunction(provideGetLogsForBlock),
 
     getTraceData: asFunction(provideGetTraceData),
     traceRpcUrl: asFunction((fortaConfig: FortaConfig) => {

--- a/cli/utils/get.logs.for.block.spec.ts
+++ b/cli/utils/get.logs.for.block.spec.ts
@@ -1,0 +1,66 @@
+import provideGetLogsForBlock, {
+  getCacheKey,
+  GetLogsForBlock,
+} from "./get.logs.for.block";
+
+describe("getLogsForBlock", () => {
+  let getLogsForBlock: GetLogsForBlock;
+  const mockEthersProvider = {
+    send: jest.fn(),
+  } as any;
+  const mockCache = {
+    getKey: jest.fn(),
+    setKey: jest.fn(),
+  } as any;
+  const mockBlockNumber = 1000;
+
+  const resetMocks = () => {
+    mockEthersProvider.send.mockReset();
+    mockCache.getKey.mockReset();
+    mockCache.setKey.mockReset();
+  };
+
+  beforeEach(() => resetMocks());
+
+  beforeAll(() => {
+    getLogsForBlock = provideGetLogsForBlock(mockEthersProvider, mockCache);
+  });
+
+  it("returns cached logs if they exist", async () => {
+    const mockLogs = [
+      { transactionHash: "0xabc", blockNumber: mockBlockNumber },
+    ];
+    mockCache.getKey.mockReturnValueOnce(mockLogs);
+
+    const logs = await getLogsForBlock(mockBlockNumber);
+
+    expect(logs).toStrictEqual(mockLogs);
+    expect(mockCache.getKey).toHaveBeenCalledTimes(1);
+    expect(mockCache.getKey).toHaveBeenCalledWith(getCacheKey(mockBlockNumber));
+    expect(mockEthersProvider.send).toHaveBeenCalledTimes(0);
+    expect(mockCache.setKey).toHaveBeenCalledTimes(0);
+  });
+
+  it("invokes eth_getLogs jsonrpc method and returns logs", async () => {
+    const mockLogs = [
+      { transactionHash: "0xabc", blockNumber: mockBlockNumber },
+    ];
+    mockEthersProvider.send.mockReturnValueOnce(mockLogs);
+
+    const logs = await getLogsForBlock(mockBlockNumber);
+
+    expect(logs).toStrictEqual(mockLogs);
+    expect(mockCache.getKey).toHaveBeenCalledTimes(1);
+    expect(mockCache.getKey).toHaveBeenCalledWith(getCacheKey(mockBlockNumber));
+    expect(mockEthersProvider.send).toHaveBeenCalledTimes(1);
+    const mockBlockNumberHex = `0x${mockBlockNumber.toString(16)}`;
+    expect(mockEthersProvider.send).toHaveBeenCalledWith("eth_getLogs", [
+      { fromBlock: mockBlockNumberHex, toBlock: mockBlockNumberHex },
+    ]);
+    expect(mockCache.setKey).toHaveBeenCalledTimes(1);
+    expect(mockCache.setKey).toHaveBeenCalledWith(
+      getCacheKey(mockBlockNumber),
+      mockLogs
+    );
+  });
+});

--- a/cli/utils/get.logs.for.block.ts
+++ b/cli/utils/get.logs.for.block.ts
@@ -1,0 +1,31 @@
+import { providers } from "ethers";
+import { Cache } from "flat-cache";
+import { assertExists } from ".";
+import { JsonRpcLog } from "./get.transaction.receipt";
+
+export type GetLogsForBlock = (blockNumber: number) => Promise<JsonRpcLog[]>;
+
+export default function provideGetLogsForBlock(
+  ethersProvider: providers.JsonRpcProvider,
+  cache: Cache
+) {
+  assertExists(ethersProvider, "ethersProvider");
+  assertExists(cache, "cache");
+
+  return async function getLogsForBlock(blockNumber: number) {
+    // check cache first
+    const cacheKey = getCacheKey(blockNumber);
+    const cachedLogs = cache.getKey(cacheKey);
+    if (cachedLogs) return cachedLogs;
+
+    // fetch logs for the block
+    const blockNumberHex = `0x${blockNumber.toString(16)}`;
+    const logs = await ethersProvider.send("eth_getLogs", [
+      { fromBlock: blockNumberHex, toBlock: blockNumberHex },
+    ]);
+    cache.setKey(cacheKey, logs);
+    return logs;
+  };
+}
+
+export const getCacheKey = (blockNumber: number) => `${blockNumber}-logs`;

--- a/cli/utils/index.spec.ts
+++ b/cli/utils/index.spec.ts
@@ -1,3 +1,4 @@
+import { getContractAddress } from '@ethersproject/address'
 import { createBlockEvent, createTransactionEvent, formatAddress, keccak256 } from "."
 import { BlockEvent, EventType, Network, TransactionEvent } from "../../sdk"
 
@@ -103,60 +104,43 @@ describe("createBlockEvent", () => {
 describe("createTransactionEvent", () => {
   it("returns correctly formatted TransactionEvent", () => {
     const networkId = 1
+    const jsonRpcTransaction = {
+      "accessList": [],
+      "blockHash": "0x550bf22138e7cd31602ecc180fac4e1d719ac52cfad41c8320078683a3b90859",
+      "blockNumber": "0x5bad55",
+      "chainId": "0x1",
+      "from": "0xC9f7bc0Ed37b821A34bFD508059c75460d6EFB37",
+      "gas": "0x249f0",
+      "gasPrice": "0x174876e800",
+      "hash": "0xfadb14c4d6bc7985583f6aded4d64bd0e071010ff4c29ab341a357550147fb28",
+      "input": "0x530ed69400000000000000000000000000000000000000000000000000000000000000050000000000000000000000000000000000000000000000000000000000000005000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000418ed8709d206b533ab0b6fc526987bff7ec7b5eae527062bb09af80f7f578231c0734276e7d4675fdf7c9fbe540578891cf9fac872d8663c7c634afb01c39f9931c00000000000000000000000000000000000000000000000000000000000000",
+      "maxFeePerGas": "0x228a814e70",
+      "maxPriorityFeePerGas": "0x59682f00",
+      "nonce": "0x5e4724",
+      "r": "0x2724a8ec2e2f3f634f04e954cf3b966bf9f734ada1611a44cd435441c83742e1",
+      "s": "0x7ae8047b83dc285a32f9fe6fb0b84927fc789e2a411ea2616deb3efd7c77a9a2",
+      "to": "0x0000000000000000000000000000000000000000",
+      "transactionIndex": "0x0",
+      "type": "0x2",
+      "v": "0x0",
+      "value": "400000000000000000"
+    }
     const jsonRpcBlock = {
       "hash": "0x550bf22138e7cd31602ecc180fac4e1d719ac52cfad41c8320078683a3b90859",
       "number": "0x5bad55",
       "timestamp": "0x5b541449",
-      "transactions": [
-          {
-            "accessList": [],
-            "blockHash": "0x550bf22138e7cd31602ecc180fac4e1d719ac52cfad41c8320078683a3b90859",
-            "blockNumber": "0x5bad55",
-            "chainId": "0x1",
-            "from": "0xC9f7bc0Ed37b821A34bFD508059c75460d6EFB37",
-            "gas": "0x249f0",
-            "gasPrice": "0x174876e800",
-            "hash": "0xfadb14c4d6bc7985583f6aded4d64bd0e071010ff4c29ab341a357550147fb28",
-            "input": "0x530ed69400000000000000000000000000000000000000000000000000000000000000050000000000000000000000000000000000000000000000000000000000000005000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000418ed8709d206b533ab0b6fc526987bff7ec7b5eae527062bb09af80f7f578231c0734276e7d4675fdf7c9fbe540578891cf9fac872d8663c7c634afb01c39f9931c00000000000000000000000000000000000000000000000000000000000000",
-            "maxFeePerGas": "0x228a814e70",
-            "maxPriorityFeePerGas": "0x59682f00",
-            "nonce": "0x5e4724",
-            "r": "0x2724a8ec2e2f3f634f04e954cf3b966bf9f734ada1611a44cd435441c83742e1",
-            "s": "0x7ae8047b83dc285a32f9fe6fb0b84927fc789e2a411ea2616deb3efd7c77a9a2",
-            "to": "0x127E479Ac59A1EA76AfdEDf830fEcc2909aA4cAE",
-            "transactionIndex": "0x0",
-            "type": "0x2",
-            "v": "0x0",
-            "value": "400000000000000000"
-          }
-      ],
+      "transactions": [jsonRpcTransaction],
     } as any
-    const jsonRpcReceipt = {
-      "blockHash": "0x550bf22138e7cd31602ecc180fac4e1d719ac52cfad41c8320078683a3b90859",
+    const jsonRpcLog = {
+      "address": "0xB9f7bc0Ed37b821A34bFD508059c75460d6EFB37",
+      "topics": ["topic1"],
+      "data": "0xdata",
+      "logIndex": "0x1",
       "blockNumber": "0x5bad55",
-      "contractAddress": "0x351d579AC59a1ea76afdedf567becc3518ee5deb",
-      "cumulativeGasUsed": "0x9af94",
-      "effectiveGasPrice": "0x1bf6a7448b",
-      "from": "0xc9f7bc0ed37b821a34bfd508059c75460d6efb37",
-      "gasUsed": "0x9af94",
-      "logs": [{
-        "address": "0xB9f7bc0Ed37b821A34bFD508059c75460d6EFB37",
-        "topics": ["topic1"],
-        "data": "0xdata",
-        "logIndex": "0x1",
-        "blockNumber": "0x5bad55",
-        "blockHash": "0x550bf22138e7cd31602ecc180fac4e1d719ac52cfad41c8320078683a3b90859",
-        "transactionIndex": "0x1",
-        "transactionHash": "0xfadb14c4d6bc7985583f6aded4d64bd0e071010ff4c29ab341a357550147fb28",
-        "removed": false
-      }],
-      "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-      "status": "0x0",
-      "to": "0x127e479ac59a1ea76afdedf830fecc2909aa4cae",
+      "blockHash": "0x550bf22138e7cd31602ecc180fac4e1d719ac52cfad41c8320078683a3b90859",
+      "transactionIndex": "0x1",
       "transactionHash": "0xfadb14c4d6bc7985583f6aded4d64bd0e071010ff4c29ab341a357550147fb28",
-      "transactionIndex": "0x0",
-      "type": "0x2",
-      "root": "0xabcd"
+      "removed": false
     }
     const traces: any = [{
       "blockHash": "0x550bf22138e7cd31602ecc180fac4e1d719ac52cfad41c8320078683a3b90859",
@@ -186,49 +170,36 @@ describe("createTransactionEvent", () => {
       "error": ""
     }]
 
-    const txEvent = createTransactionEvent(jsonRpcReceipt, jsonRpcBlock, networkId, traces)
+    const txEvent = createTransactionEvent(jsonRpcTransaction, jsonRpcBlock, networkId, traces, [jsonRpcLog])
 
     expect(txEvent).toBeInstanceOf(TransactionEvent)
     expect(txEvent.type).toEqual(EventType.BLOCK)
     expect(txEvent.network).toEqual(Network.MAINNET)
-    const web3Tx = jsonRpcBlock.transactions[0]
     expect(txEvent.transaction).toStrictEqual({
-      hash: web3Tx.hash,
-      from: formatAddress(web3Tx.from),
-      to: formatAddress(web3Tx.to),
-      nonce: parseInt(web3Tx.nonce),
-      gas: web3Tx.gas,
-      gasPrice: web3Tx.gasPrice,
-      value: web3Tx.value,
-      data: web3Tx.input,
-      r: web3Tx.r,
-      s: web3Tx.s,
-      v: web3Tx.v
+      hash: jsonRpcTransaction.hash,
+      from: formatAddress(jsonRpcTransaction.from),
+      to: formatAddress(jsonRpcTransaction.to),
+      nonce: parseInt(jsonRpcTransaction.nonce),
+      gas: jsonRpcTransaction.gas,
+      gasPrice: jsonRpcTransaction.gasPrice,
+      value: jsonRpcTransaction.value,
+      data: jsonRpcTransaction.input,
+      r: jsonRpcTransaction.r,
+      s: jsonRpcTransaction.s,
+      v: jsonRpcTransaction.v
     })
-    const web3Log = jsonRpcReceipt.logs[0]
-    expect(txEvent.receipt).toStrictEqual({
-      blockNumber: parseInt(jsonRpcReceipt.blockNumber),
-      blockHash: jsonRpcReceipt.blockHash,
-      transactionIndex: parseInt(jsonRpcReceipt.transactionIndex),
-      transactionHash: jsonRpcReceipt.transactionHash,
-      status: jsonRpcReceipt.status === "0x1",
-      logsBloom: jsonRpcReceipt.logsBloom,
-      contractAddress: formatAddress(jsonRpcReceipt.contractAddress),
-      gasUsed: jsonRpcReceipt.gasUsed,
-      cumulativeGasUsed: jsonRpcReceipt.cumulativeGasUsed,
-      root: jsonRpcReceipt.root,
-      logs: [{
-        address: formatAddress(web3Log.address),
-        topics: web3Log.topics,
-        data: web3Log.data,
-        logIndex: parseInt(web3Log.logIndex),
-        blockNumber: parseInt(web3Log.blockNumber),
-        blockHash: web3Log.blockHash,
-        transactionIndex: parseInt(web3Log.transactionIndex),
-        transactionHash: web3Log.transactionHash,
-        removed: web3Log.removed
-      }]
-    })
+    expect(txEvent.logs).toStrictEqual([{
+        address: formatAddress(jsonRpcLog.address),
+        topics: jsonRpcLog.topics,
+        data: jsonRpcLog.data,
+        logIndex: parseInt(jsonRpcLog.logIndex),
+        blockNumber: parseInt(jsonRpcLog.blockNumber),
+        blockHash: jsonRpcLog.blockHash,
+        transactionIndex: parseInt(jsonRpcLog.transactionIndex),
+        transactionHash: jsonRpcLog.transactionHash,
+        removed: jsonRpcLog.removed
+      }
+    ])
     expect(txEvent.traces).toStrictEqual(traces.map((trace: any) => ({
       action: {
         callType: trace.action.callType,
@@ -258,9 +229,9 @@ describe("createTransactionEvent", () => {
     })))
     const traceAction = traces[0].action
     expect(txEvent.addresses).toStrictEqual({
-      [formatAddress(web3Tx.from)]: true,
-      [formatAddress(web3Tx.to)]: true,
-      [formatAddress(web3Log.address)]: true,
+      [formatAddress(jsonRpcTransaction.from)]: true,
+      [formatAddress(jsonRpcTransaction.to)]: true,
+      [formatAddress(jsonRpcLog.address)]: true,
       [formatAddress(traceAction.address)]: true,
       [formatAddress(traceAction.refundAddress)]: true,
       [formatAddress(traceAction.to)]: true,
@@ -271,5 +242,6 @@ describe("createTransactionEvent", () => {
       number: parseInt(jsonRpcBlock.number),
       timestamp: parseInt(jsonRpcBlock.timestamp)
     })
+    expect(txEvent.contractAddress).toEqual(formatAddress(getContractAddress({ from: jsonRpcTransaction.from, nonce: jsonRpcTransaction.nonce })))
   })
 })

--- a/cli/utils/index.ts
+++ b/cli/utils/index.ts
@@ -106,7 +106,6 @@ export const createTransactionEvent: CreateTransactionEvent = (
   if (tx.to) {
     addresses[tx.to] = true;
   }
-  logs.forEach(log => addresses[log.address] = true)
 
   const blok = {
     hash: block.hash,
@@ -161,6 +160,7 @@ export const createTransactionEvent: CreateTransactionEvent = (
     transactionHash: log.transactionHash,
     removed: log.removed,
   }))
+  lgs.forEach(log => addresses[log.address] = true)
 
   let contractAddress = null
   if (isZeroAddress(transaction.to)) {

--- a/cli/utils/run.handlers.on.block.spec.ts
+++ b/cli/utils/run.handlers.on.block.spec.ts
@@ -5,8 +5,8 @@ describe("runHandlersOnBlock", () => {
   const mockGetAgentHandlers = jest.fn()
   const mockGetNetworkId = jest.fn()
   const mockGetBlockWithTransactions = jest.fn()
-  const mockGetTransactionReceipt = jest.fn()
   const mockGetTraceData = jest.fn().mockReturnValue([])
+  const mockGetLogsForBlock = jest.fn().mockReturnValue([])
   const mockCreateBlockEvent = jest.fn()
   const mockCreateTransactionEvent = jest.fn()
   const mockBlockHash = '0xabc'
@@ -14,7 +14,8 @@ describe("runHandlersOnBlock", () => {
 
   beforeAll(() => {
     runHandlersOnBlock = provideRunHandlersOnBlock(
-      mockGetAgentHandlers, mockGetNetworkId, mockGetBlockWithTransactions, mockGetTransactionReceipt, mockGetTraceData, mockCreateBlockEvent, mockCreateTransactionEvent
+      mockGetAgentHandlers, mockGetNetworkId, mockGetBlockWithTransactions, mockGetTraceData, 
+      mockGetLogsForBlock, mockCreateBlockEvent, mockCreateTransactionEvent
     )
   })
 
@@ -37,12 +38,15 @@ describe("runHandlersOnBlock", () => {
     mockGetAgentHandlers.mockReturnValueOnce({ handleBlock: mockHandleBlock, handleTransaction: mockHandleTransaction })
     const mockNetworkId = 1
     mockGetNetworkId.mockReturnValueOnce(mockNetworkId)
-    const mockBlock = { hash: mockBlockHash, number: 7, transactions: [{ hash: mockTxHash }] }
+    const mockTransaction = { hash: mockTxHash }
+    const mockBlock = { hash: mockBlockHash, number: 7, transactions: [mockTransaction] }
     mockGetBlockWithTransactions.mockReturnValueOnce(mockBlock)
     const mockBlockEvent = {}
     mockCreateBlockEvent.mockReturnValueOnce(mockBlockEvent)
-    const mockReceipt = { transactionHash: mockTxHash }
-    mockGetTransactionReceipt.mockReturnValueOnce(mockReceipt)
+    const mockTrace = { transactionHash: mockTxHash, some: 'trace' }
+    mockGetTraceData.mockReturnValueOnce([mockTrace])
+    const mockLog = { transactionHash: mockTxHash, some: 'log' }
+    mockGetLogsForBlock.mockReturnValueOnce([mockLog])
     const mockTxEvent = {}
     mockCreateTransactionEvent.mockReturnValueOnce(mockTxEvent)
 
@@ -58,12 +62,12 @@ describe("runHandlersOnBlock", () => {
     expect(mockCreateBlockEvent).toHaveBeenCalledWith(mockBlock, mockNetworkId)
     expect(mockHandleBlock).toHaveBeenCalledTimes(1)
     expect(mockHandleBlock).toHaveBeenCalledWith(mockBlockEvent)
+    expect(mockGetLogsForBlock).toHaveBeenCalledTimes(1)
+    expect(mockGetLogsForBlock).toHaveBeenCalledWith(mockBlock.number)
     expect(mockGetTraceData).toHaveBeenCalledTimes(1)
     expect(mockGetTraceData).toHaveBeenCalledWith(mockBlock.number)
-    expect(mockGetTransactionReceipt).toHaveBeenCalledTimes(1)
-    expect(mockGetTransactionReceipt).toHaveBeenCalledWith(mockTxHash)
     expect(mockCreateTransactionEvent).toHaveBeenCalledTimes(1)
-    expect(mockCreateTransactionEvent).toHaveBeenCalledWith(mockReceipt, mockBlock, mockNetworkId, undefined)
+    expect(mockCreateTransactionEvent).toHaveBeenCalledWith(mockTransaction, mockBlock, mockNetworkId, [mockTrace], [mockLog])
     expect(mockHandleTransaction).toHaveBeenCalledTimes(1)
     expect(mockHandleTransaction).toHaveBeenCalledWith(mockTxEvent)
   })

--- a/cli/utils/run.handlers.on.transaction.spec.ts
+++ b/cli/utils/run.handlers.on.transaction.spec.ts
@@ -34,10 +34,14 @@ describe("runHandlersOnTransaction", () => {
     mockGetAgentHandlers.mockReturnValueOnce({ handleTransaction: mockHandleTransaction })
     const mockNetworkId = 1
     mockGetNetworkId.mockReturnValueOnce(mockNetworkId)
-    const mockReceipt = { blockNumber: 123, transactionHash: mockTxHash }
+    const mockLog = { some: 'log' }
+    const mockReceipt = { blockNumber: 123, transactionHash: mockTxHash, logs: [mockLog] }
     mockGetTransactionReceipt.mockReturnValueOnce(mockReceipt)
-    const mockBlock = { hash: '0xabc' }
+    const mockTransaction = { hash: mockTxHash }
+    const mockBlock = { hash: '0xabc', transactions: [mockTransaction] }
     mockGetBlockWithTransactions.mockReturnValueOnce(mockBlock)
+    const mockTrace = { some: 'trace' }
+    mockGetTraceData.mockReturnValueOnce([mockTrace])
     const mockTxEvent = {}
     mockCreateTransactionEvent.mockReturnValueOnce(mockTxEvent)
 
@@ -54,7 +58,7 @@ describe("runHandlersOnTransaction", () => {
     expect(mockGetTraceData).toHaveBeenCalledTimes(1)
     expect(mockGetTraceData).toHaveBeenCalledWith(mockReceipt.transactionHash)
     expect(mockCreateTransactionEvent).toHaveBeenCalledTimes(1)
-    expect(mockCreateTransactionEvent).toHaveBeenCalledWith(mockReceipt, mockBlock, mockNetworkId, [])
+    expect(mockCreateTransactionEvent).toHaveBeenCalledWith(mockTransaction, mockBlock, mockNetworkId, [mockTrace], [mockLog])
     expect(mockHandleTransaction).toHaveBeenCalledTimes(1)
     expect(mockHandleTransaction).toHaveBeenCalledWith(mockTxEvent)
   })

--- a/cli/utils/run.handlers.on.transaction.ts
+++ b/cli/utils/run.handlers.on.transaction.ts
@@ -31,8 +31,9 @@ export function provideRunHandlersOnTransaction(
     const networkId = await getNetworkId()
     const receipt = await getTransactionReceipt(txHash)
     const block = await getBlockWithTransactions(parseInt(receipt.blockNumber))
+    const transaction = block.transactions.find(tx => tx.hash === receipt.transactionHash)!
     const traces = await getTraceData(receipt.transactionHash)
-    const txEvent = createTransactionEvent(receipt, block, networkId, traces)
+    const txEvent = createTransactionEvent(transaction, block, networkId, traces, receipt.logs)
 
     const findings = await handleTransaction(txEvent)
     console.log(`${findings.length} findings for transaction ${txHash} ${findings}`)

--- a/cli/utils/run.handlers.on.transaction.ts
+++ b/cli/utils/run.handlers.on.transaction.ts
@@ -28,13 +28,16 @@ export function provideRunHandlersOnTransaction(
       throw new Error("no transaction handler found")
     }
       
-    const networkId = await getNetworkId()
-    const receipt = await getTransactionReceipt(txHash)
+    const [ networkId, receipt, traces ] = await Promise.all([
+      getNetworkId(),
+      getTransactionReceipt(txHash),
+      getTraceData(txHash)
+    ])
     const block = await getBlockWithTransactions(parseInt(receipt.blockNumber))
-    const transaction = block.transactions.find(tx => tx.hash === receipt.transactionHash)!
-    const traces = await getTraceData(receipt.transactionHash)
-    const txEvent = createTransactionEvent(transaction, block, networkId, traces, receipt.logs)
 
+    txHash = txHash.toLowerCase()
+    const transaction = block.transactions.find(tx => tx.hash.toLowerCase() === txHash)!
+    const txEvent = createTransactionEvent(transaction, block, networkId, traces, receipt.logs)
     const findings = await handleTransaction(txEvent)
     console.log(`${findings.length} findings for transaction ${txHash} ${findings}`)
   }

--- a/python-sdk/src/forta_agent/__init__.py
+++ b/python-sdk/src/forta_agent/__init__.py
@@ -7,7 +7,7 @@ from .receipt import Receipt, Log
 from .trace import Trace, TraceAction, TraceResult
 from .event_type import EventType
 from .network import Network
-from .utils import get_json_rpc_url, create_block_event, create_transaction_event, get_web3_provider, keccak256
+from .utils import get_json_rpc_url, create_block_event, create_transaction_event, get_web3_provider, keccak256, get_transaction_receipt
 from web3 import Web3
 
 web3Provider = Web3(Web3.HTTPProvider(get_json_rpc_url()))

--- a/python-sdk/src/forta_agent/transaction_event.py
+++ b/python-sdk/src/forta_agent/transaction_event.py
@@ -3,7 +3,7 @@ from hexbytes import HexBytes
 from .event_type import EventType
 from .network import Network
 from .transaction import Transaction
-from .receipt import Receipt
+from .receipt import Log
 from .trace import Trace
 
 
@@ -25,10 +25,12 @@ class TransactionEvent:
         self.network = Network[networkVal] if type(
             networkVal) == str else Network(networkVal)
         self.transaction = Transaction(dict.get('transaction', {}))
-        self.receipt = Receipt(dict.get('receipt', {}))
         self.traces = list(map(lambda t: Trace(t), dict.get('traces', [])))
         self.addresses = dict.get('addresses', {})
         self.block = TxEventBlock(dict.get('block', {}))
+        self.logs = list(map(lambda l: Log(l), dict.get('logs', [])))
+        self.contract_address = dict.get(
+            'contractAddress', dict.get('contract_address'))
 
     @property
     def hash(self):
@@ -43,20 +45,8 @@ class TransactionEvent:
         return self.transaction.from_
 
     @property
-    def status(self):
-        return self.receipt.status
-
-    @property
-    def gas_used(self):
-        return self.receipt.gas_used
-
-    @property
     def gas_price(self):
         return self.transaction.gas_price
-
-    @property
-    def logs(self):
-        return self.receipt.logs
 
     @property
     def timestamp(self):

--- a/python-sdk/src/forta_agent/utils.py
+++ b/python-sdk/src/forta_agent/utils.py
@@ -42,6 +42,35 @@ def get_json_rpc_url():
     return config.get("jsonRpcUrl")
 
 
+def get_transaction_receipt(tx_hash):
+    from .receipt import Receipt  # avoid circular import
+    web3_provider = get_web3_provider()
+    receipt = web3_provider.eth.get_transaction_receipt(tx_hash)
+    return Receipt({
+        "status": receipt.get("status") == 1,
+        "root": receipt.get("root"),
+        "gas_used": receipt.get("gasUsed"),
+        "cumulative_gas_used": receipt.get("cumulativeGasUsed"),
+        "logs_bloom": receipt.get("logsBloom").hex(),
+        "contract_address": None if receipt.get("contractAddress") == None else receipt.get("contractAddress").lower(),
+        "block_number": receipt.get("blockNumber"),
+        "block_hash": receipt.get("blockHash").hex(),
+        "transaction_index": receipt.get("transactionIndex"),
+        "transaction_hash": receipt.get("transactionHash").hex(),
+        "logs": list(map(lambda log: {
+            "address": log.get("address").lower(),
+            "topics": list(map(lambda topic: topic.hex(), log.get("topics", []))),
+            "data": log.get("data"),
+            "log_index": log.get("logIndex"),
+            "block_number": log.get("blockNumber"),
+            "block_hash": log.get("blockHash").hex(),
+            "transaction_index": log.get("transactionIndex"),
+            "transaction_hash": log.get("transactionHash").hex(),
+            "removed": log.get("removed")
+        }, receipt.get("logs", []))),
+    })
+
+
 def create_block_event(dict):
     from .block_event import BlockEvent  # avoid circular import
     return BlockEvent(dict)

--- a/sdk/index.ts
+++ b/sdk/index.ts
@@ -14,7 +14,8 @@ import {
   getEthersBatchProvider, 
   keccak256,
   setPrivateFindings,
-  isPrivateFindings
+  isPrivateFindings,
+  getTransactionReceipt
 } from "./utils"
 import awilixConfigureContainer from '../cli/di.container';
 
@@ -96,5 +97,6 @@ export {
   keccak256,
   setPrivateFindings,
   isPrivateFindings,
-  configureContainer
+  configureContainer,
+  getTransactionReceipt
  }

--- a/sdk/transaction.event.ts
+++ b/sdk/transaction.event.ts
@@ -1,5 +1,5 @@
 import { EventType, Network } from "./index";
-import { Receipt } from "./receipt";
+import { Log } from "./receipt";
 import { Trace } from "./trace";
 import { Transaction } from "./transaction";
 import { ethers } from ".";
@@ -21,10 +21,11 @@ export class TransactionEvent {
     readonly type: EventType,
     readonly network: Network,
     readonly transaction: Transaction,
-    readonly receipt: Receipt,
     readonly traces: Trace[] = [],
     readonly addresses: { [key: string]: boolean },
-    readonly block: TxEventBlock
+    readonly block: TxEventBlock,
+    readonly logs: Log[] = [],
+    readonly contractAddress: string | null
   ) {}
 
   get hash() {
@@ -39,20 +40,8 @@ export class TransactionEvent {
     return this.transaction.to;
   }
 
-  get status() {
-    return this.receipt.status;
-  }
-
-  get gasUsed() {
-    return this.receipt.gasUsed;
-  }
-
   get gasPrice() {
     return this.transaction.gasPrice;
-  }
-
-  get logs() {
-    return this.receipt.logs;
   }
 
   get timestamp() {
@@ -72,7 +61,7 @@ export class TransactionEvent {
     contractAddress?: string | string[]
   ): LogDescription[] {
     eventAbi = _.isArray(eventAbi) ? eventAbi : [eventAbi];
-    let logs = this.receipt.logs;
+    let logs = this.logs;
     // filter logs by contract address, if provided
     if (contractAddress) {
       contractAddress = _.isArray(contractAddress)

--- a/starter-project/js/package.json
+++ b/starter-project/js/package.json
@@ -18,7 +18,6 @@
     "test": "jest"
   },
   "dependencies": {
-    "bignumber.js": "^9.0.1",
     "forta-agent": "^0.0.41"
   },
   "devDependencies": {

--- a/starter-project/js/src/agent.js
+++ b/starter-project/js/src/agent.js
@@ -1,6 +1,9 @@
-const BigNumber = require("bignumber.js");
 const { Finding, FindingSeverity, FindingType } = require("forta-agent");
 
+const ERC20_TRANSFER_EVENT =
+  "event Transfer(address indexed from, address indexed to, uint256 value)";
+const TETHER_ADDRESS = "0xdAC17F958D2ee523a2206206994597C13D831ec7";
+const TETHER_DECIMALS = 6;
 let findingsCount = 0;
 
 const handleTransaction = async (txEvent) => {
@@ -9,20 +12,29 @@ const handleTransaction = async (txEvent) => {
   // limiting this agent to emit only 5 findings so that the alert feed is not spammed
   if (findingsCount >= 5) return findings;
 
-  // create finding if gas used is higher than threshold
-  const gasUsed = new BigNumber(txEvent.gasUsed);
-  if (gasUsed.isGreaterThan("1000000")) {
-    findings.push(
-      Finding.fromObject({
-        name: "High Gas Used",
-        description: `Gas Used: ${gasUsed}`,
-        alertId: "FORTA-1",
-        severity: FindingSeverity.Medium,
-        type: FindingType.Suspicious,
-      })
-    );
-    findingsCount++;
-  }
+  // filter the transaction logs for Tether transfer events
+  const tetherTransferEvents = txEvent.filterLog(
+    ERC20_TRANSFER_EVENT,
+    TETHER_ADDRESS
+  );
+
+  tetherTransferEvents.forEach((transferEvent) => {
+    // shift decimals of transfer value
+    const value = transferEvent.args.value.div(10 ** TETHER_DECIMALS);
+    // if more than 10,000 Tether were transferred, report it
+    if (value.gt(10000)) {
+      findings.push(
+        Finding.fromObject({
+          name: "High Tether Transfer",
+          description: `High amount of USDT transferred: ${value}`,
+          alertId: "FORTA-1",
+          severity: FindingSeverity.Low,
+          type: FindingType.Info,
+        })
+      );
+      findingsCount++;
+    }
+  });
 
   return findings;
 };
@@ -36,4 +48,7 @@ const handleTransaction = async (txEvent) => {
 module.exports = {
   handleTransaction,
   // handleBlock,
+  ERC20_TRANSFER_EVENT, // exported for unit tests
+  TETHER_ADDRESS, // exported for unit tests
+  TETHER_DECIMALS, // exported for unit tests
 };

--- a/starter-project/js/src/agent.spec.js
+++ b/starter-project/js/src/agent.spec.js
@@ -3,38 +3,66 @@ const {
   FindingSeverity,
   Finding,
   createTransactionEvent,
+  ethers,
 } = require("forta-agent");
-const { handleTransaction } = require("./agent");
+const {
+  handleTransaction,
+  ERC20_TRANSFER_EVENT,
+  TETHER_ADDRESS,
+  TETHER_DECIMALS,
+} = require("./agent");
 
-describe("high gas agent", () => {
-  const createTxEventWithGasUsed = (gasUsed) =>
-    createTransactionEvent({
-      receipt: { gasUsed },
+describe("high tether transfer agent", () => {
+  describe("handleTransaction", () => {
+    const mockTxEvent = createTransactionEvent({});
+    mockTxEvent.filterLog = jest.fn();
+
+    beforeEach(() => {
+      mockTxEvent.filterLog.mockReset();
     });
 
-  describe("handleTransaction", () => {
-    it("returns empty findings if gas used is below threshold", async () => {
-      const txEvent = createTxEventWithGasUsed("1");
+    it("returns empty findings if there are no Tether transfers", async () => {
+      mockTxEvent.filterLog.mockReturnValue([]);
 
-      const findings = await handleTransaction(txEvent);
+      const findings = await handleTransaction(mockTxEvent);
 
       expect(findings).toStrictEqual([]);
+      expect(mockTxEvent.filterLog).toHaveBeenCalledTimes(1);
+      expect(mockTxEvent.filterLog).toHaveBeenCalledWith(
+        ERC20_TRANSFER_EVENT,
+        TETHER_ADDRESS
+      );
     });
 
-    it("returns a finding if gas used is above threshold", async () => {
-      const txEvent = createTxEventWithGasUsed("1000001");
+    it("returns a finding if there is a Tether transfer over 10,000", async () => {
+      const mockTetherTransferEvent = {
+        args: {
+          from: "0xabc",
+          to: "0xdef",
+          value: ethers.BigNumber.from("20000000000"), //20k with 6 decimals
+        },
+      };
+      mockTxEvent.filterLog.mockReturnValue([mockTetherTransferEvent]);
 
-      const findings = await handleTransaction(txEvent);
+      const findings = await handleTransaction(mockTxEvent);
 
+      const normalizedValue = mockTetherTransferEvent.args.value.div(
+        10 ** TETHER_DECIMALS
+      );
       expect(findings).toStrictEqual([
         Finding.fromObject({
-          name: "High Gas Used",
-          description: `Gas Used: ${txEvent.gasUsed}`,
+          name: "High Tether Transfer",
+          description: `High amount of USDT transferred: ${normalizedValue}`,
           alertId: "FORTA-1",
-          type: FindingType.Suspicious,
-          severity: FindingSeverity.Medium,
+          severity: FindingSeverity.Low,
+          type: FindingType.Info,
         }),
       ]);
+      expect(mockTxEvent.filterLog).toHaveBeenCalledTimes(1);
+      expect(mockTxEvent.filterLog).toHaveBeenCalledWith(
+        ERC20_TRANSFER_EVENT,
+        TETHER_ADDRESS
+      );
     });
   });
 });

--- a/starter-project/py/src/agent.py
+++ b/starter-project/py/src/agent.py
@@ -1,42 +1,35 @@
 from forta_agent import Finding, FindingType, FindingSeverity
 
-MEDIUM_GAS_THRESHOLD = 1000000
-HIGH_GAS_THRESHOLD = 3000000
-CRITICAL_GAS_THRESHOLD = 7000000
-
+ERC20_TRANSFER_EVENT = '{"name":"Transfer","type":"event","anonymous":false,"inputs":[{"indexed":true,"name":"from","type":"address"},{"indexed":true,"name":"to","type":"address"},{"indexed":false,"name":"value","type":"uint256"}]}'
+TETHER_ADDRESS = '0xdAC17F958D2ee523a2206206994597C13D831ec7'
+TETHER_DECIMALS = 6
 findings_count = 0
 
 
 def handle_transaction(transaction_event):
     findings = []
-    gas_used = int(transaction_event.gas_used)
 
     # limiting this agent to emit only 5 findings so that the alert feed is not spammed
     global findings_count
     if findings_count >= 5:
         return findings
 
-    if gas_used < MEDIUM_GAS_THRESHOLD:
-        return findings
+    # filter the transaction logs for any Tether transfers
+    tether_transfer_events = transaction_event.filter_log(
+        ERC20_TRANSFER_EVENT, TETHER_ADDRESS)
 
-    findings.append(Finding({
-        'name': 'High Gas Used',
-        'description': f'Gas Used: {gas_used}',
-        'alert_id': 'FORTA-1',
-        'type': FindingType.Suspicious,
-        'severity': get_severity(gas_used),
-        'metadata': {
-            'gas_used': gas_used
-        }
-    }))
-    findings_count += 1
+    for transfer_event in tether_transfer_events:
+        # shift decimals of transfer value
+        value = transfer_event['args']['value'] / 10 ** TETHER_DECIMALS
+        # if more than 10,000 Tether were transferred, report it
+        if value > 10000:
+            findings.append(Finding({
+                'name': 'High Tether Transfer',
+                'description': f'High amount of USDT transferred: {value}',
+                'alert_id': 'FORTA-1',
+                'severity': FindingSeverity.Low,
+                'type': FindingType.Info,
+            }))
+            findings_count += 1
+
     return findings
-
-
-def get_severity(gas_used):
-    if gas_used > CRITICAL_GAS_THRESHOLD:
-        return FindingSeverity.Critical
-    elif gas_used > HIGH_GAS_THRESHOLD:
-        return FindingSeverity.High
-    else:
-        return FindingSeverity.Medium

--- a/starter-project/py/src/agent_test.py
+++ b/starter-project/py/src/agent_test.py
@@ -1,28 +1,36 @@
+from unittest.mock import Mock
 from forta_agent import FindingSeverity, FindingType, create_transaction_event
-from agent import handle_transaction
+from agent import handle_transaction, ERC20_TRANSFER_EVENT, TETHER_ADDRESS, TETHER_DECIMALS
+
+mock_tx_event = create_transaction_event({})
+mock_tx_event.filter_log = Mock()
 
 
-class TestHighGasAgent:
-    def test_returns_empty_findings_if_gas_below_threshold(self):
-        tx_event = create_transaction_event(
-            {'receipt': {'gas_used': '1'}})
+class TestHighTetherTransferAgent:
+    def test_returns_empty_findings_if_no_tether_transfers(self):
+        mock_tx_event.filter_log.return_value = []
 
-        findings = handle_transaction(tx_event)
+        findings = handle_transaction(mock_tx_event)
 
         assert len(findings) == 0
+        mock_tx_event.filter_log.assert_called_once_with(
+            ERC20_TRANSFER_EVENT, TETHER_ADDRESS)
 
-    def test_returns_finding_if_gas_above_threshold(self):
-        tx_event = create_transaction_event({
-            'receipt': {'gas_used': '1000001'}
-        })
+    def test_returns_finding_if_tether_transfer_over_10k(self):
+        mock_tx_event.filter_log.reset_mock()
+        amount = 20000
+        mock_transfer_event = {
+            'args': {'value': amount * 10**TETHER_DECIMALS, 'from': '0x123', 'to': '0xabc'}}
+        mock_tx_event.filter_log.return_value = [mock_transfer_event]
 
-        findings = handle_transaction(tx_event)
+        findings = handle_transaction(mock_tx_event)
 
         assert len(findings) == 1
+        mock_tx_event.filter_log.assert_called_once_with(
+            ERC20_TRANSFER_EVENT, TETHER_ADDRESS)
         finding = findings[0]
-        assert finding.name == "High Gas Used"
-        assert finding.description == f'Gas Used: {tx_event.gas_used}'
-        assert finding.alert_id == 'FORTA-1'
-        assert finding.type == FindingType.Suspicious
-        assert finding.severity == FindingSeverity.Medium
-        assert finding.metadata['gas_used'] == tx_event.gas_used
+        assert finding.name == "High Tether Transfer"
+        assert finding.description == f'High amount of USDT transferred: {mock_transfer_event["args"]["value"] / 10**TETHER_DECIMALS}'
+        assert finding.alert_id == "FORTA-1"
+        assert finding.severity == FindingSeverity.Low
+        assert finding.type == FindingType.Info

--- a/starter-project/ts/package.json
+++ b/starter-project/ts/package.json
@@ -19,7 +19,6 @@
     "test": "jest"
   },
   "dependencies": {
-    "bignumber.js": "^9.0.1",
     "forta-agent": "^0.0.41"
   },
   "devDependencies": {

--- a/starter-project/ts/src/agent.spec.ts
+++ b/starter-project/ts/src/agent.spec.ts
@@ -3,46 +3,68 @@ import {
   FindingSeverity,
   Finding,
   HandleTransaction,
-  createTransactionEvent
-} from "forta-agent"
-import agent from "./agent"
+  createTransactionEvent,
+  ethers,
+} from "forta-agent";
+import agent, {
+  ERC20_TRANSFER_EVENT,
+  TETHER_ADDRESS,
+  TETHER_DECIMALS,
+} from "./agent";
 
-describe("high gas agent", () => {
-  let handleTransaction: HandleTransaction
-
-  const createTxEventWithGasUsed = (gasUsed: string) => createTransactionEvent({
-    transaction: {} as any,
-    receipt: { gasUsed } as any,
-    block: {} as any,
-  })
+describe("high tether transfer agent", () => {
+  let handleTransaction: HandleTransaction;
+  const mockTxEvent = createTransactionEvent({} as any);
 
   beforeAll(() => {
-    handleTransaction = agent.handleTransaction
-  })
+    handleTransaction = agent.handleTransaction;
+  });
 
   describe("handleTransaction", () => {
-    it("returns empty findings if gas used is below threshold", async () => {
-      const txEvent = createTxEventWithGasUsed("1")
+    it("returns empty findings if there are no Tether transfers", async () => {
+      mockTxEvent.filterLog = jest.fn().mockReturnValue([]);
 
-      const findings = await handleTransaction(txEvent)
+      const findings = await handleTransaction(mockTxEvent);
 
-      expect(findings).toStrictEqual([])
-    })
+      expect(findings).toStrictEqual([]);
+      expect(mockTxEvent.filterLog).toHaveBeenCalledTimes(1);
+      expect(mockTxEvent.filterLog).toHaveBeenCalledWith(
+        ERC20_TRANSFER_EVENT,
+        TETHER_ADDRESS
+      );
+    });
 
-    it("returns a finding if gas used is above threshold", async () => {
-      const txEvent = createTxEventWithGasUsed("1000001")
+    it("returns a finding if there is a Tether transfer over 10,000", async () => {
+      const mockTetherTransferEvent = {
+        args: {
+          from: "0xabc",
+          to: "0xdef",
+          value: ethers.BigNumber.from("20000000000"), //20k with 6 decimals
+        },
+      };
+      mockTxEvent.filterLog = jest
+        .fn()
+        .mockReturnValue([mockTetherTransferEvent]);
 
-      const findings = await handleTransaction(txEvent)
+      const findings = await handleTransaction(mockTxEvent);
 
+      const normalizedValue = mockTetherTransferEvent.args.value.div(
+        10 ** TETHER_DECIMALS
+      );
       expect(findings).toStrictEqual([
         Finding.fromObject({
-          name: "High Gas Used",
-          description: `Gas Used: ${txEvent.gasUsed}`,
+          name: "High Tether Transfer",
+          description: `High amount of USDT transferred: ${normalizedValue}`,
           alertId: "FORTA-1",
-          type: FindingType.Suspicious,
-          severity: FindingSeverity.Medium
+          severity: FindingSeverity.Low,
+          type: FindingType.Info,
         }),
-      ])
-    })
-  })
-})
+      ]);
+      expect(mockTxEvent.filterLog).toHaveBeenCalledTimes(1);
+      expect(mockTxEvent.filterLog).toHaveBeenCalledWith(
+        ERC20_TRANSFER_EVENT,
+        TETHER_ADDRESS
+      );
+    });
+  });
+});

--- a/starter-project/ts/src/agent.ts
+++ b/starter-project/ts/src/agent.ts
@@ -1,37 +1,53 @@
-import BigNumber from 'bignumber.js'
-import { 
-  BlockEvent, 
-  Finding, 
-  HandleBlock, 
-  HandleTransaction, 
-  TransactionEvent, 
-  FindingSeverity, 
-  FindingType 
-} from 'forta-agent'
+import {
+  BlockEvent,
+  Finding,
+  HandleBlock,
+  HandleTransaction,
+  TransactionEvent,
+  FindingSeverity,
+  FindingType,
+} from "forta-agent";
 
-let findingsCount = 0
+export const ERC20_TRANSFER_EVENT =
+  "event Transfer(address indexed from, address indexed to, uint256 value)";
+export const TETHER_ADDRESS = "0xdAC17F958D2ee523a2206206994597C13D831ec7";
+export const TETHER_DECIMALS = 6;
+let findingsCount = 0;
 
-const handleTransaction: HandleTransaction = async (txEvent: TransactionEvent) => {
-  const findings: Finding[] = []
+const handleTransaction: HandleTransaction = async (
+  txEvent: TransactionEvent
+) => {
+  const findings: Finding[] = [];
 
   // limiting this agent to emit only 5 findings so that the alert feed is not spammed
   if (findingsCount >= 5) return findings;
 
-  // create finding if gas used is higher than threshold
-  const gasUsed = new BigNumber(txEvent.gasUsed)
-  if (gasUsed.isGreaterThan("1000000")) {
-    findings.push(Finding.fromObject({
-      name: "High Gas Used",
-      description: `Gas Used: ${gasUsed}`,
-      alertId: "FORTA-1",
-      severity: FindingSeverity.Medium,
-      type: FindingType.Suspicious
-    }))
-    findingsCount++
-  }
+  // filter the transaction logs for Tether transfer events
+  const tetherTransferEvents = txEvent.filterLog(
+    ERC20_TRANSFER_EVENT,
+    TETHER_ADDRESS
+  );
 
-  return findings
-}
+  tetherTransferEvents.forEach((transferEvent) => {
+    // shift decimals of transfer value
+    const normalizedValue = transferEvent.args.value.div(10 ** TETHER_DECIMALS);
+    // if more than 10,000 Tether were transferred, report it
+    if (normalizedValue.gt(10000)) {
+      findings.push(
+        Finding.fromObject({
+          name: "High Tether Transfer",
+          description: `High amount of USDT transferred: ${normalizedValue}`,
+          alertId: "FORTA-1",
+          severity: FindingSeverity.Low,
+          type: FindingType.Info,
+        })
+      );
+      findingsCount++;
+    }
+  });
+
+  return findings;
+};
 
 // const handleBlock: HandleBlock = async (blockEvent: BlockEvent) => {
 //   const findings: Finding[] = [];
@@ -42,4 +58,4 @@ const handleTransaction: HandleTransaction = async (txEvent: TransactionEvent) =
 export default {
   handleTransaction,
   // handleBlock
-}
+};


### PR DESCRIPTION
- update agent.proto to deprecate TransactionEvent.Receipt and add TransactionEvent.logs
- update JS and Python SDK to remove `receipt` property from TransactionEvent and add `logs` property
- update `run` CLI command to not fetch transaction receipts, instead get logs for whole block
- add `getTransactionReceipt` convenience method to SDK
- update starter projects to scan for high tether transfers